### PR TITLE
Add calendar app documentation and domain layer skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,29 @@
-# work01
+# Work01 Calendar App
+
+A product specification and Kotlin domain layer prototype for an Android calendar application. The app focuses on three primary capabilities:
+
+1. **Scheduler** – create and manage events or tasks on specific dates and times.
+2. **Alarm reminders** – configure notifications to remind users ahead of upcoming items.
+3. **Task lists** – view actionable to-do lists for each day, week, or month with completion tracking.
+
+The repository contains documentation for requirements, architecture decisions, and Kotlin domain logic that can be adapted into a full Android project.
+
+## Repository layout
+
+- `docs/` – requirements, architecture, and UX planning notes.
+- `app/src/main/kotlin/` – Kotlin domain-layer prototypes (data models, use cases, and view models).
+
+## Getting started
+
+These files are intended as a foundation for bootstrapping a full Android Studio project:
+
+1. Copy the `app/src/main/kotlin` package into your Android project.
+2. Wire the domain classes to persistence (Room, Realm, etc.) and notification APIs.
+3. Implement UI layers (Jetpack Compose or XML) guided by the UX flows in the documentation.
+
+## Next steps
+
+- Integrate the domain logic with Android frameworks (ViewModel, WorkManager, AlarmManager).
+- Persist data using Room or another database solution.
+- Build Compose-based calendar and task list UI components.
+- Add instrumentation/unit tests for scheduling logic and reminder calculations.

--- a/app/src/main/kotlin/com/example/calendar/data/CalendarEvent.kt
+++ b/app/src/main/kotlin/com/example/calendar/data/CalendarEvent.kt
@@ -1,0 +1,32 @@
+package com.example.calendar.data
+
+import java.time.LocalDateTime
+import java.util.UUID
+
+data class CalendarEvent(
+    val id: UUID = UUID.randomUUID(),
+    val title: String,
+    val description: String? = null,
+    val start: LocalDateTime,
+    val end: LocalDateTime,
+    val location: String? = null,
+    val reminders: List<Reminder> = emptyList(),
+    val recurrence: Recurrence? = null
+) {
+    init {
+        require(!end.isBefore(start)) { "Event end time must be after start time" }
+    }
+}
+
+data class Recurrence(
+    val rule: RecurrenceRule,
+    val interval: Int = 1,
+    val occurrences: Int? = null
+)
+
+enum class RecurrenceRule {
+    Daily,
+    Weekly,
+    Monthly,
+    Yearly
+}

--- a/app/src/main/kotlin/com/example/calendar/data/EventRepository.kt
+++ b/app/src/main/kotlin/com/example/calendar/data/EventRepository.kt
@@ -1,0 +1,12 @@
+package com.example.calendar.data
+
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
+
+interface EventRepository {
+    fun observeEventsForDay(date: LocalDate): Flow<List<CalendarEvent>>
+    fun observeEventsForRange(start: LocalDate, end: LocalDate): Flow<List<CalendarEvent>>
+
+    suspend fun upsert(event: CalendarEvent)
+    suspend fun delete(id: java.util.UUID)
+}

--- a/app/src/main/kotlin/com/example/calendar/data/Task.kt
+++ b/app/src/main/kotlin/com/example/calendar/data/Task.kt
@@ -1,0 +1,47 @@
+package com.example.calendar.data
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.UUID
+
+/**
+ * Represents a to-do item that can appear within daily, weekly, or monthly agenda views.
+ */
+data class Task(
+    val id: UUID = UUID.randomUUID(),
+    val title: String,
+    val description: String? = null,
+    val status: TaskStatus = TaskStatus.Pending,
+    val dueAt: LocalDateTime? = null,
+    val period: AgendaPeriod,
+    val reminders: List<Reminder> = emptyList(),
+    val tags: Set<String> = emptySet()
+) {
+    fun toggleCompletion(): Task = copy(
+        status = if (status.isDone()) TaskStatus.Pending else TaskStatus.Completed
+    )
+
+    fun isOverdue(currentDateTime: LocalDateTime = LocalDateTime.now()): Boolean {
+        val deadline = dueAt ?: return false
+        return status != TaskStatus.Completed && deadline.isBefore(currentDateTime)
+    }
+}
+
+sealed class AgendaPeriod {
+    data class Day(val date: LocalDate) : AgendaPeriod()
+    data class Week(val start: LocalDate) : AgendaPeriod() {
+        val end: LocalDate = start.plusDays(6)
+    }
+    data class Month(val year: Int, val month: Int) : AgendaPeriod() {
+        val firstDay: LocalDate = LocalDate.of(year, month, 1)
+        val lastDay: LocalDate = firstDay.plusMonths(1).minusDays(1)
+    }
+}
+
+/**
+ * Reminder offset relative to the task's due time.
+ */
+data class Reminder(
+    val minutesBefore: Long,
+    val allowSnooze: Boolean = true
+)

--- a/app/src/main/kotlin/com/example/calendar/data/TaskRepository.kt
+++ b/app/src/main/kotlin/com/example/calendar/data/TaskRepository.kt
@@ -1,0 +1,15 @@
+package com.example.calendar.data
+
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDate
+import java.util.UUID
+
+interface TaskRepository {
+    fun observeTasksForDay(date: LocalDate): Flow<List<Task>>
+    fun observeTasksForWeek(start: LocalDate): Flow<List<Task>>
+    fun observeTasksForMonth(year: Int, month: Int): Flow<List<Task>>
+
+    suspend fun upsert(task: Task)
+    suspend fun toggleStatus(id: UUID)
+    suspend fun delete(id: UUID)
+}

--- a/app/src/main/kotlin/com/example/calendar/data/TaskStatus.kt
+++ b/app/src/main/kotlin/com/example/calendar/data/TaskStatus.kt
@@ -1,0 +1,9 @@
+package com.example.calendar.data
+
+enum class TaskStatus {
+    Pending,
+    InProgress,
+    Completed;
+
+    fun isDone(): Boolean = this == Completed
+}

--- a/app/src/main/kotlin/com/example/calendar/reminder/ReminderOrchestrator.kt
+++ b/app/src/main/kotlin/com/example/calendar/reminder/ReminderOrchestrator.kt
@@ -1,0 +1,66 @@
+package com.example.calendar.reminder
+
+import com.example.calendar.data.CalendarEvent
+import com.example.calendar.data.Reminder
+import com.example.calendar.data.Task
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+class ReminderOrchestrator(
+    private val scheduler: ReminderScheduler,
+    private val zoneId: ZoneId = ZoneId.systemDefault()
+) {
+    fun scheduleForTask(task: Task) {
+        val dueAt = task.dueAt ?: return
+        scheduleReminders(
+            baseId = "task-${task.id}",
+            title = task.title,
+            targetDateTime = dueAt,
+            reminders = task.reminders,
+            deepLink = "app://task/${task.id}",
+            allowSnooze = true
+        )
+    }
+
+    fun scheduleForEvent(event: CalendarEvent) {
+        scheduleReminders(
+            baseId = "event-${event.id}",
+            title = event.title,
+            targetDateTime = event.start,
+            reminders = event.reminders,
+            deepLink = "app://event/${event.id}",
+            allowSnooze = false
+        )
+    }
+
+    fun cancelForTask(task: Task) = scheduler.cancelReminder("task-${task.id}")
+    fun cancelForEvent(event: CalendarEvent) = scheduler.cancelReminder("event-${event.id}")
+
+    private fun scheduleReminders(
+        baseId: String,
+        title: String,
+        targetDateTime: LocalDateTime,
+        reminders: List<Reminder>,
+        deepLink: String,
+        allowSnooze: Boolean
+    ) {
+        reminders.forEachIndexed { index, reminder ->
+            val trigger = targetDateTime.minusMinutes(reminder.minutesBefore)
+            val zonedTrigger: ZonedDateTime = trigger.atZone(zoneId)
+            if (zonedTrigger.isAfter(ZonedDateTime.now(zoneId))) {
+                scheduler.scheduleReminder(
+                    id = "$baseId-$index",
+                    triggerAt = zonedTrigger.toLocalDateTime(),
+                    reminder = reminder,
+                    payload = ReminderPayload(
+                        title = title,
+                        message = "${reminder.minutesBefore}분 전에 알림",
+                        deepLink = deepLink,
+                        allowSnooze = allowSnooze && reminder.allowSnooze
+                    )
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/calendar/reminder/ReminderScheduler.kt
+++ b/app/src/main/kotlin/com/example/calendar/reminder/ReminderScheduler.kt
@@ -1,0 +1,25 @@
+package com.example.calendar.reminder
+
+import com.example.calendar.data.Reminder
+import java.time.LocalDateTime
+
+/**
+ * Abstraction over Android's alarm APIs to simplify testing and reuse.
+ */
+interface ReminderScheduler {
+    fun scheduleReminder(
+        id: String,
+        triggerAt: LocalDateTime,
+        reminder: Reminder,
+        payload: ReminderPayload
+    )
+
+    fun cancelReminder(id: String)
+}
+
+data class ReminderPayload(
+    val title: String,
+    val message: String,
+    val deepLink: String,
+    val allowSnooze: Boolean
+)

--- a/app/src/main/kotlin/com/example/calendar/scheduler/AgendaAggregator.kt
+++ b/app/src/main/kotlin/com/example/calendar/scheduler/AgendaAggregator.kt
@@ -1,0 +1,64 @@
+package com.example.calendar.scheduler
+
+import com.example.calendar.data.AgendaPeriod
+import com.example.calendar.data.CalendarEvent
+import com.example.calendar.data.EventRepository
+import com.example.calendar.data.Task
+import com.example.calendar.data.TaskRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.map
+import java.time.LocalDate
+
+/**
+ * Produces a combined agenda of events and tasks for a selected period.
+ */
+class AgendaAggregator(
+    private val taskRepository: TaskRepository,
+    private val eventRepository: EventRepository
+) {
+    fun observeAgenda(period: AgendaPeriod): Flow<AgendaSnapshot> = when (period) {
+        is AgendaPeriod.Day -> observeDay(period.date)
+        is AgendaPeriod.Week -> observeWeek(period.start)
+        is AgendaPeriod.Month -> observeMonth(period.year, period.month)
+    }
+
+    private fun observeDay(date: LocalDate): Flow<AgendaSnapshot> = combine(
+        taskRepository.observeTasksForDay(date),
+        eventRepository.observeEventsForDay(date)
+    ) { tasks, events ->
+        AgendaSnapshot(date, tasks, events)
+    }
+
+    private fun observeWeek(start: LocalDate): Flow<AgendaSnapshot> {
+        val end = start.plusDays(6)
+        return combine(
+            taskRepository.observeTasksForWeek(start),
+            eventRepository.observeEventsForRange(start, end)
+        ) { tasks, events ->
+            AgendaSnapshot(start, tasks, events)
+        }.map { snapshot -> snapshot.copy(rangeEnd = end) }
+    }
+
+    private fun observeMonth(year: Int, month: Int): Flow<AgendaSnapshot> {
+        val firstDay = LocalDate.of(year, month, 1)
+        val lastDay = firstDay.plusMonths(1).minusDays(1)
+        return combine(
+            taskRepository.observeTasksForMonth(year, month),
+            eventRepository.observeEventsForRange(firstDay, lastDay)
+        ) { tasks, events ->
+            AgendaSnapshot(firstDay, tasks, events)
+        }.map { snapshot -> snapshot.copy(rangeEnd = lastDay) }
+    }
+}
+
+data class AgendaSnapshot(
+    val rangeStart: LocalDate,
+    val tasks: List<Task>,
+    val events: List<CalendarEvent>,
+    val rangeEnd: LocalDate = rangeStart
+) {
+    val overdueTasks: List<Task> = tasks.filter { it.isOverdue() }
+    val completedCount: Int = tasks.count { it.status.isDone() }
+    val pendingCount: Int = tasks.size - completedCount
+}

--- a/app/src/main/kotlin/com/example/calendar/ui/AgendaViewModel.kt
+++ b/app/src/main/kotlin/com/example/calendar/ui/AgendaViewModel.kt
@@ -1,0 +1,74 @@
+package com.example.calendar.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.calendar.data.AgendaPeriod
+import com.example.calendar.data.Task
+import com.example.calendar.scheduler.AgendaAggregator
+import com.example.calendar.scheduler.AgendaSnapshot
+import com.example.calendar.reminder.ReminderOrchestrator
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+
+class AgendaViewModel(
+    private val aggregator: AgendaAggregator,
+    private val reminderOrchestrator: ReminderOrchestrator
+) : ViewModel() {
+
+    private val _period = MutableStateFlow<AgendaPeriod>(AgendaPeriod.Day(java.time.LocalDate.now()))
+    private val _state = MutableStateFlow(AgendaUiState())
+    val state: StateFlow<AgendaUiState> = _state.asStateFlow()
+
+    init {
+        observePeriod()
+    }
+
+    fun setPeriod(period: AgendaPeriod) {
+        if (_period.value != period) {
+            _period.value = period
+        }
+    }
+
+    fun toggleTask(task: Task) {
+        viewModelScope.launch {
+            reminderOrchestrator.cancelForTask(task)
+            val toggled = task.toggleCompletion()
+            if (!toggled.status.isDone() && toggled.dueAt != null) {
+                reminderOrchestrator.scheduleForTask(toggled)
+            }
+            _state.value = _state.value.updateTask(toggled)
+        }
+    }
+
+    private fun observePeriod() {
+        _period.onEach { period ->
+            aggregator.observeAgenda(period)
+                .onEach { snapshot ->
+                    _state.value = _state.value.copy(
+                        snapshot = snapshot,
+                        isLoading = false,
+                        error = null
+                    )
+                }
+                .launchIn(viewModelScope)
+        }.launchIn(viewModelScope)
+    }
+}
+
+data class AgendaUiState(
+    val snapshot: AgendaSnapshot? = null,
+    val isLoading: Boolean = true,
+    val error: Throwable? = null
+) {
+    fun updateTask(task: Task): AgendaUiState {
+        val current = snapshot ?: return this
+        val updatedTasks = current.tasks.map { existing ->
+            if (existing.id == task.id) task else existing
+        }
+        return copy(snapshot = current.copy(tasks = updatedTasks))
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,55 @@
+# Architecture overview
+
+The calendar application is structured using a clean architecture-inspired approach with three layers:
+
+1. **Presentation (UI/ViewModel)** – Jetpack Compose screens backed by ViewModels that expose state flows.
+2. **Domain** – Use cases and business logic governing scheduling, reminder calculation, and task completion.
+3. **Data** – Repository implementations that coordinate Room database, AlarmManager integrations, and optional remote sync.
+
+```
+┌──────────────┐      ┌──────────────┐      ┌───────────────┐
+│   Compose    │◀────▶│  ViewModel   │◀────▶│   Use Cases    │
+└──────────────┘      └──────────────┘      └───────────────┘
+                                           ▲            ▲
+                                           │            │
+                                   ┌─────────────┐ ┌──────────────┐
+                                   │Repositories │ │ AlarmWorker  │
+                                   └─────────────┘ └──────────────┘
+                                           ▲            ▲
+                                           │            │
+                                   ┌──────────────┐ ┌──────────────┐
+                                   │   Room DB    │ │ Notification │
+                                   │              │ │  Scheduler   │
+                                   └──────────────┘ └──────────────┘
+```
+
+## Domain layer components
+
+- `Task` and `CalendarEvent` models capture common scheduling properties.
+- `AgendaPeriod` sealed class encapsulates day/week/month ranges.
+- `TaskRepository` and `EventRepository` interfaces expose flows of domain models.
+- Use cases (e.g., `CreateTaskUseCase`, `GetAgendaUseCase`, `ScheduleReminderUseCase`) orchestrate business rules.
+
+## Reminder scheduling
+
+- A `ReminderScheduler` translates domain reminders into OS-level alarms.
+- Reminders are persisted in Room with metadata for restoration after reboot.
+- WorkManager handles long-running or network-dependent operations.
+
+## UI considerations
+
+- Compose screens subscribe to `StateFlow` data exposed by ViewModels.
+- Weekly/monthly calendars share a core `CalendarGridState` to reuse selection/highlighting logic.
+- Tasks leverage lazy column lists with swipe actions for quick completion toggles.
+
+## Data persistence
+
+- Room entities mirror domain models with converters for recurrence rules.
+- DAO queries provide aggregated lists for day/week/month filtering.
+- Repository implementations map DAO results to domain models and dispatch reminder scheduling side effects.
+
+## Testing strategy
+
+- Unit tests for use cases mock repositories to verify business logic.
+- Instrumented tests interact with Room + AlarmManager using Robolectric or emulator.
+- Snapshot tests ensure Compose calendar views render expected states.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -1,0 +1,36 @@
+# Functional requirements
+
+## Core calendar & scheduling
+- Users can create, edit, and delete calendar items that contain a title, optional description, start/end time, and optional location.
+- Calendar items may be one-off events or repeating tasks (daily, weekly, monthly, or custom recurrence rules).
+- Events appear on the calendar in daily, weekly, and monthly views.
+
+## Task management
+- Each calendar day may contain a to-do list with actionable tasks.
+- Tasks can be marked as `Pending`, `InProgress`, or `Completed`.
+- Tasks inherit the date context of their parent (day/week/month) but can also include explicit deadlines.
+- Users can filter lists by completion state and recurrence type.
+
+## Alarm & reminder system
+- Users can attach one or more reminders to events and tasks.
+- Reminders support offsets (e.g., 10 minutes before, 1 hour before, 1 day before).
+- Reminder delivery uses Android's `AlarmManager` or `WorkManager` for reliability across device reboot.
+- When a reminder triggers, the user receives a notification with quick actions (snooze, mark done, open details).
+
+## Agenda aggregation
+- The app aggregates all scheduled items into a consolidated agenda for the selected period (day/week/month).
+- Agenda screens surface overdue items and highlight conflicts between events.
+
+## Data persistence & sync
+- Local storage uses Room with Flow/LiveData streams for UI updates.
+- Optional cloud sync via Firebase or a future backend service keeps devices in sync.
+
+## Accessibility & localization
+- All interactions support TalkBack and dynamic font sizing.
+- Internationalization uses string resources to allow Korean/English translation.
+
+# Non-functional requirements
+- Follow Material 3 guidelines for visual design.
+- Offline-first behavior with background sync when connectivity returns.
+- Unit and instrumentation tests cover scheduling, reminder calculations, and database queries.
+- Modular architecture to support feature scaling.

--- a/docs/ux-flows.md
+++ b/docs/ux-flows.md
@@ -1,0 +1,36 @@
+# UX flow summary
+
+## Onboarding
+1. User selects preferred start of week (Sunday or Monday) and default reminder time.
+2. Optional sign-in to enable cross-device sync.
+
+## Home agenda view
+1. Default landing surface showing today's agenda.
+2. Hero section summarises current day events, overdue tasks, and upcoming reminders.
+3. Horizontal pager toggles between Day, Week, and Month contexts.
+
+## Creating a task/event
+1. Tap floating action button to open creation sheet.
+2. Choose between `Event` or `Task` templates.
+3. Enter core details (title, start date/time, recurrence, description, tags).
+4. Add reminders with relative offsets or absolute times.
+5. Save triggers repository insert + reminder scheduling.
+
+## Managing tasks
+- Swipe right to mark complete; left to snooze with quick reminder presets.
+- Tap to view details, edit recurrence, or attach subtasks.
+- Completed tasks appear collapsed but can be expanded for review.
+
+## Weekly & monthly navigation
+- Gesture or arrow navigation to move between periods.
+- Tap a day cell in week/month view to update the agenda list below.
+- Indicators display number of tasks, events, and overdue items per day.
+
+## Notifications
+- Reminder notification includes actions for `Snooze 10m`, `Complete`, and `Open`.
+- Tapping `Complete` updates repository and refreshes widgets.
+- Notification channels for events vs tasks allow custom sound/vibration.
+
+## Widgets
+- Resizable agenda widget for Android home screen showing next events.
+- Quick add widget to capture tasks with voice input integration.


### PR DESCRIPTION
## Summary
- add documentation covering requirements, architecture, and UX flows for the Android calendar app
- introduce Kotlin domain models, repositories, and scheduling logic prototypes for tasks, events, and reminders
- provide a Compose-oriented AgendaViewModel to demonstrate how agenda data can power UI screens

## Testing
- not run (documentation and Kotlin stubs only)


------
https://chatgpt.com/codex/tasks/task_e_68dcd7fc7e14832d8d05af6ffd9762ac