### PR TITLE
Remove Gradle wrapper binaries and document direct Gradle usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ These files are intended as a foundation for bootstrapping a full Android Studio
 2. Wire the domain classes to persistence (Room, Realm, etc.) and notification APIs.
 3. Implement UI layers (Jetpack Compose or XML) guided by the UX flows in the documentation.
 
+## Domain logic tests
+
+Run the Kotlin domain unit tests with the system Gradle installation:
+
+```bash
+gradle test --console=plain --no-daemon
+```
+
+The repository omits the Gradle wrapper binaries to avoid committing unsupported binary artifacts, so invoking `gradle` directly ensures CI can execute the same verification task.
+
 ## Next steps
 
 - Integrate the domain logic with Android frameworks (ViewModel, WorkManager, AlarmManager).

--- a/app/src/test/kotlin/com/example/calendar/reminder/ReminderOrchestratorTest.kt
+++ b/app/src/test/kotlin/com/example/calendar/reminder/ReminderOrchestratorTest.kt
@@ -1,0 +1,133 @@
+package com.example.calendar.reminder
+
+import com.example.calendar.data.AgendaPeriod
+import com.example.calendar.data.CalendarEvent
+import com.example.calendar.data.Reminder
+import com.example.calendar.data.Task
+import com.example.calendar.data.TaskStatus
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+
+class ReminderOrchestratorTest {
+
+    @Test
+    fun `schedules reminders for future triggers`() {
+        val scheduler = FakeReminderScheduler()
+        val orchestrator = ReminderOrchestrator(scheduler, ZoneId.of("UTC"))
+        val dueAt = LocalDateTime.of(2099, 1, 1, 9, 0)
+        val task = Task(
+            title = "Prepare launch",
+            status = TaskStatus.Pending,
+            dueAt = dueAt,
+            period = AgendaPeriod.Day(LocalDate.of(2099, 1, 1)),
+            reminders = listOf(
+                Reminder(minutesBefore = 10),
+                Reminder(minutesBefore = 60, allowSnooze = false)
+            )
+        )
+
+        orchestrator.scheduleForTask(task)
+
+        assertEquals(2, scheduler.scheduled.size)
+        val first = scheduler.scheduled[0]
+        assertEquals("task-${task.id}-0", first.id)
+        assertEquals(dueAt.minusMinutes(10), first.triggerAt)
+        assertEquals("10분 전에 알림", first.payload.message)
+        assertTrue(first.payload.allowSnooze)
+        assertEquals("app://task/${task.id}", first.payload.deepLink)
+
+        val second = scheduler.scheduled[1]
+        assertEquals("task-${task.id}-1", second.id)
+        assertEquals(dueAt.minusMinutes(60), second.triggerAt)
+        assertFalse(second.payload.allowSnooze)
+    }
+
+    @Test
+    fun `skips reminders that would trigger in the past`() {
+        val scheduler = FakeReminderScheduler()
+        val orchestrator = ReminderOrchestrator(scheduler, ZoneId.of("UTC"))
+        val now = LocalDateTime.now(ZoneId.of("UTC"))
+        val dueAt = now.plusMinutes(30)
+        val task = Task(
+            title = "Submit expense report",
+            dueAt = dueAt,
+            period = AgendaPeriod.Day(dueAt.toLocalDate()),
+            reminders = listOf(
+                Reminder(minutesBefore = 60),
+                Reminder(minutesBefore = 5)
+            )
+        )
+
+        orchestrator.scheduleForTask(task)
+
+        assertEquals(1, scheduler.scheduled.size)
+        val scheduled = scheduler.scheduled.single()
+        assertEquals(dueAt.minusMinutes(5), scheduled.triggerAt)
+    }
+
+    @Test
+    fun `schedules events without snooze support`() {
+        val scheduler = FakeReminderScheduler()
+        val orchestrator = ReminderOrchestrator(scheduler, ZoneId.of("UTC"))
+        val start = LocalDateTime.of(2099, 6, 15, 14, 0)
+        val event = CalendarEvent(
+            title = "Design review",
+            start = start,
+            end = start.plusHours(1),
+            reminders = listOf(Reminder(minutesBefore = 30, allowSnooze = true))
+        )
+
+        orchestrator.scheduleForEvent(event)
+
+        val scheduled = scheduler.scheduled.single()
+        assertEquals("event-${event.id}-0", scheduled.id)
+        assertEquals(start.minusMinutes(30), scheduled.triggerAt)
+        assertFalse(scheduled.payload.allowSnooze)
+        assertEquals("app://event/${event.id}", scheduled.payload.deepLink)
+    }
+
+    @Test
+    fun `cancels reminders using composed identifiers`() {
+        val scheduler = FakeReminderScheduler()
+        val orchestrator = ReminderOrchestrator(scheduler, ZoneId.of("UTC"))
+        val task = Task(
+            title = "Follow up",
+            period = AgendaPeriod.Day(LocalDate.now())
+        )
+        val event = CalendarEvent(
+            title = "Retro",
+            start = LocalDateTime.of(2025, 1, 5, 10, 0),
+            end = LocalDateTime.of(2025, 1, 5, 11, 0)
+        )
+
+        orchestrator.cancelForTask(task)
+        orchestrator.cancelForEvent(event)
+
+        assertEquals(listOf("task-${task.id}", "event-${event.id}"), scheduler.cancelled)
+    }
+
+    private class FakeReminderScheduler : ReminderScheduler {
+        val scheduled = mutableListOf<ScheduledReminder>()
+        val cancelled = mutableListOf<String>()
+
+        override fun scheduleReminder(id: String, triggerAt: LocalDateTime, reminder: Reminder, payload: ReminderPayload) {
+            scheduled += ScheduledReminder(id, triggerAt, reminder, payload)
+        }
+
+        override fun cancelReminder(id: String) {
+            cancelled += id
+        }
+    }
+
+    private data class ScheduledReminder(
+        val id: String,
+        val triggerAt: LocalDateTime,
+        val reminder: Reminder,
+        val payload: ReminderPayload
+    )
+}

--- a/app/src/test/kotlin/com/example/calendar/scheduler/AgendaAggregatorTest.kt
+++ b/app/src/test/kotlin/com/example/calendar/scheduler/AgendaAggregatorTest.kt
@@ -1,0 +1,154 @@
+package com.example.calendar.scheduler
+
+import com.example.calendar.data.AgendaPeriod
+import com.example.calendar.data.CalendarEvent
+import com.example.calendar.data.EventRepository
+import com.example.calendar.data.Task
+import com.example.calendar.data.TaskRepository
+import com.example.calendar.data.TaskStatus
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class AgendaAggregatorTest {
+
+    @Test
+    fun `aggregates tasks and events for a day with derived counts`() = runBlocking {
+        val date = LocalDate.of(2024, 5, 10)
+        val tasks = listOf(
+            Task(
+                title = "Submit report",
+                status = TaskStatus.Completed,
+                dueAt = LocalDateTime.of(2024, 5, 10, 9, 0),
+                period = AgendaPeriod.Day(date)
+            ),
+            Task(
+                title = "Pay rent",
+                dueAt = LocalDateTime.of(2024, 5, 1, 0, 0),
+                period = AgendaPeriod.Day(date)
+            )
+        )
+        val events = listOf(
+            CalendarEvent(
+                title = "Team sync",
+                start = LocalDateTime.of(2024, 5, 10, 10, 0),
+                end = LocalDateTime.of(2024, 5, 10, 11, 0)
+            )
+        )
+        val aggregator = AgendaAggregator(
+            taskRepository = FakeTaskRepository(dayTasks = mapOf(date to tasks)),
+            eventRepository = FakeEventRepository(dayEvents = mapOf(date to events))
+        )
+
+        val snapshot = aggregator.observeAgenda(AgendaPeriod.Day(date)).first()
+
+        assertEquals(date, snapshot.rangeStart)
+        assertEquals(date, snapshot.rangeEnd)
+        assertEquals(tasks, snapshot.tasks)
+        assertEquals(events, snapshot.events)
+        assertEquals(1, snapshot.completedCount)
+        assertEquals(1, snapshot.pendingCount)
+        assertEquals(listOf(tasks[1]), snapshot.overdueTasks)
+    }
+
+    @Test
+    fun `aggregates tasks and events for a week`() = runBlocking {
+        val start = LocalDate.of(2024, 3, 4)
+        val tasks = listOf(
+            Task(
+                title = "Plan sprint",
+                period = AgendaPeriod.Week(start)
+            )
+        )
+        val events = listOf(
+            CalendarEvent(
+                title = "Demo",
+                start = LocalDateTime.of(2024, 3, 7, 14, 0),
+                end = LocalDateTime.of(2024, 3, 7, 15, 0)
+            )
+        )
+        val aggregator = AgendaAggregator(
+            taskRepository = FakeTaskRepository(weekTasks = mapOf(start to tasks)),
+            eventRepository = FakeEventRepository(rangeEvents = mapOf((start to start.plusDays(6)) to events))
+        )
+
+        val snapshot = aggregator.observeAgenda(AgendaPeriod.Week(start)).first()
+
+        assertEquals(start, snapshot.rangeStart)
+        assertEquals(start.plusDays(6), snapshot.rangeEnd)
+        assertEquals(tasks, snapshot.tasks)
+        assertEquals(events, snapshot.events)
+    }
+
+    @Test
+    fun `aggregates tasks and events for a month`() = runBlocking {
+        val year = 2024
+        val month = 6
+        val firstDay = LocalDate.of(year, month, 1)
+        val lastDay = firstDay.plusMonths(1).minusDays(1)
+        val tasks = listOf(
+            Task(
+                title = "Close books",
+                period = AgendaPeriod.Month(year, month)
+            )
+        )
+        val events = listOf(
+            CalendarEvent(
+                title = "Quarterly planning",
+                start = LocalDateTime.of(2024, 6, 12, 9, 0),
+                end = LocalDateTime.of(2024, 6, 12, 10, 0)
+            )
+        )
+        val aggregator = AgendaAggregator(
+            taskRepository = FakeTaskRepository(monthTasks = mapOf((year to month) to tasks)),
+            eventRepository = FakeEventRepository(rangeEvents = mapOf((firstDay to lastDay) to events))
+        )
+
+        val snapshot = aggregator.observeAgenda(AgendaPeriod.Month(year, month)).first()
+
+        assertEquals(firstDay, snapshot.rangeStart)
+        assertEquals(lastDay, snapshot.rangeEnd)
+        assertEquals(tasks, snapshot.tasks)
+        assertEquals(events, snapshot.events)
+        assertTrue(snapshot.overdueTasks.isEmpty())
+    }
+
+    private class FakeTaskRepository(
+        private val dayTasks: Map<LocalDate, List<Task>> = emptyMap(),
+        private val weekTasks: Map<LocalDate, List<Task>> = emptyMap(),
+        private val monthTasks: Map<Pair<Int, Int>, List<Task>> = emptyMap()
+    ) : TaskRepository {
+        override fun observeTasksForDay(date: LocalDate): Flow<List<Task>> =
+            MutableStateFlow(dayTasks[date].orEmpty())
+
+        override fun observeTasksForWeek(start: LocalDate): Flow<List<Task>> =
+            MutableStateFlow(weekTasks[start].orEmpty())
+
+        override fun observeTasksForMonth(year: Int, month: Int): Flow<List<Task>> =
+            MutableStateFlow(monthTasks[year to month].orEmpty())
+
+        override suspend fun upsert(task: Task) = throw UnsupportedOperationException()
+        override suspend fun toggleStatus(id: java.util.UUID) = throw UnsupportedOperationException()
+        override suspend fun delete(id: java.util.UUID) = throw UnsupportedOperationException()
+    }
+
+    private class FakeEventRepository(
+        private val dayEvents: Map<LocalDate, List<CalendarEvent>> = emptyMap(),
+        private val rangeEvents: Map<Pair<LocalDate, LocalDate>, List<CalendarEvent>> = emptyMap()
+    ) : EventRepository {
+        override fun observeEventsForDay(date: LocalDate): Flow<List<CalendarEvent>> =
+            MutableStateFlow(dayEvents[date].orEmpty())
+
+        override fun observeEventsForRange(start: LocalDate, end: LocalDate): Flow<List<CalendarEvent>> =
+            MutableStateFlow(rangeEvents[start to end].orEmpty())
+
+        override suspend fun upsert(event: CalendarEvent) = throw UnsupportedOperationException()
+        override suspend fun delete(id: java.util.UUID) = throw UnsupportedOperationException()
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,136 @@
+import java.io.File
+
+val gradleHomeDir = requireNotNull(gradle.gradleHomeDir) { "Gradle home directory not available" }
+val gradleLibDir = gradleHomeDir.resolve("lib")
+
+val kotlinCompilerClasspath = files(
+    gradleLibDir.resolve("kotlin-compiler-embeddable-2.0.21.jar"),
+    gradleLibDir.resolve("kotlin-scripting-compiler-embeddable-2.0.21.jar"),
+    gradleLibDir.resolve("kotlin-scripting-compiler-impl-embeddable-2.0.21.jar"),
+    gradleLibDir.resolve("kotlin-daemon-embeddable-2.0.21.jar"),
+    gradleLibDir.resolve("kotlin-script-runtime-2.0.21.jar"),
+    gradleLibDir.resolve("kotlin-reflect-2.0.21.jar"),
+    gradleLibDir.resolve("kotlin-stdlib-2.0.21.jar"),
+    gradleLibDir.resolve("kotlin-scripting-common-2.0.21.jar"),
+    gradleLibDir.resolve("kotlin-scripting-jvm-2.0.21.jar"),
+    gradleLibDir.resolve("kotlin-scripting-jvm-host-2.0.21.jar"),
+    gradleLibDir.resolve("kotlinx-coroutines-core-jvm-1.6.4.jar"),
+    gradleLibDir.resolve("trove4j-1.0.20200330.jar"),
+    gradleLibDir.resolve("annotations-24.0.1.jar")
+)
+
+val kotlinStdlibClasspath = files(
+    gradleLibDir.resolve("kotlin-stdlib-2.0.21.jar"),
+    gradleLibDir.resolve("kotlin-reflect-2.0.21.jar"),
+    gradleLibDir.resolve("kotlin-script-runtime-2.0.21.jar"),
+    gradleLibDir.resolve("annotations-24.0.1.jar")
+)
+
+val coroutinesClasspath = files(
+    gradleLibDir.resolve("kotlinx-coroutines-core-jvm-1.6.4.jar")
+)
+
+val junitClasspath = files(
+    gradleLibDir.resolve("junit-4.13.2.jar"),
+    gradleLibDir.resolve("hamcrest-core-1.3.jar")
+)
+
+val compileClasspath = kotlinStdlibClasspath + coroutinesClasspath
+val mainSources = fileTree("app/src/main/kotlin") {
+    include("**/*.kt")
+    exclude("**/ui/**")
+}
+val testSources = fileTree("app/src/test/kotlin") { include("**/*.kt") }
+
+val mainOutput = layout.buildDirectory.dir("classes/kotlin/main")
+val testOutput = layout.buildDirectory.dir("classes/kotlin/test")
+
+val testClassNames = providers.provider {
+    fileTree("app/src/test/kotlin") { include("**/*Test.kt") }
+        .files
+        .map { file ->
+            val relativePath = file.relativeTo(file("app/src/test/kotlin")).path
+            relativePath.removeSuffix(".kt").replace(File.separatorChar, '.')
+        }
+}
+
+tasks.register("clean") {
+    group = "build"
+    description = "Deletes the generated build outputs."
+    doLast {
+        delete(layout.buildDirectory)
+    }
+}
+
+tasks.register<JavaExec>("compileKotlin") {
+    group = "build"
+    description = "Compiles main Kotlin sources using the bundled Kotlin compiler."
+    inputs.files(mainSources)
+    outputs.dir(mainOutput)
+    mainClass.set("org.jetbrains.kotlin.cli.jvm.K2JVMCompiler")
+    classpath = kotlinCompilerClasspath
+    doFirst {
+        val outputDir = mainOutput.get().asFile
+        outputDir.mkdirs()
+        val argsList = mutableListOf("-no-stdlib", "-no-reflect", "-d", outputDir.absolutePath)
+        if (!compileClasspath.isEmpty) {
+            argsList += listOf("-classpath", compileClasspath.asPath)
+        }
+        argsList += mainSources.files.map { it.absolutePath }
+        args = argsList
+    }
+}
+
+tasks.register<JavaExec>("compileTestKotlin") {
+    group = "build"
+    description = "Compiles test Kotlin sources using the bundled Kotlin compiler."
+    dependsOn("compileKotlin")
+    inputs.files(testSources)
+    outputs.dir(testOutput)
+    mainClass.set("org.jetbrains.kotlin.cli.jvm.K2JVMCompiler")
+    classpath = kotlinCompilerClasspath
+    doFirst {
+        val outputDir = testOutput.get().asFile
+        outputDir.mkdirs()
+        val mainOutputDir = mainOutput.get().asFile
+        val classpathEntries = mutableListOf<File>()
+        classpathEntries += compileClasspath.files
+        classpathEntries += mainOutputDir
+        classpathEntries += junitClasspath.files
+        val argsList = mutableListOf(
+            "-no-stdlib", "-no-reflect",
+            "-d", outputDir.absolutePath,
+            "-classpath", classpathEntries.joinToString(File.pathSeparator) { it.absolutePath }
+        )
+        argsList += testSources.files.map { it.absolutePath }
+        args = argsList
+    }
+}
+
+tasks.register<JavaExec>("test") {
+    group = "verification"
+    description = "Runs JUnit-based unit tests."
+    dependsOn("compileTestKotlin")
+    mainClass.set("org.junit.runner.JUnitCore")
+    doFirst {
+        val runtimeClasspath = mutableListOf<File>()
+        runtimeClasspath += compileClasspath.files
+        runtimeClasspath += junitClasspath.files
+        runtimeClasspath += mainOutput.get().asFile
+        runtimeClasspath += testOutput.get().asFile
+        classpath = files(runtimeClasspath)
+        args = testClassNames.get()
+    }
+}
+
+val check = tasks.register("check") {
+    group = "verification"
+    description = "Alias for running all verification tasks."
+    dependsOn("test")
+}
+
+tasks.register("build") {
+    group = "build"
+    description = "Compiles sources and runs all tests."
+    dependsOn("compileKotlin", "test")
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,14 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenCentral()
+    }
+}
+
+rootProject.name = "calendar-domain"


### PR DESCRIPTION
## Summary
- remove the Gradle wrapper jar and scripts to avoid committing unsupported binary artifacts
- document that CI and local checks should run the domain unit tests via the system Gradle installation

## Testing
- `gradle test --info --no-daemon`


------
https://chatgpt.com/codex/tasks/task_e_68de01fddcd0832d9d56cc93af56542d