### PR TITLE
Add Room database layer for calendar data

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,33 @@
+import org.gradle.api.JavaVersion
+
+plugins {
+    id("com.android.library")
+    kotlin("android")
+    kotlin("kapt")
+}
+
+android {
+    namespace = "com.example.calendar"
+    compileSdk = 34
+
+    defaultConfig {
+        minSdk = 26
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.13.1")
+
+    implementation("androidx.room:room-runtime:2.6.1")
+    implementation("androidx.room:room-ktx:2.6.1")
+    kapt("androidx.room:room-compiler:2.6.1")
+}

--- a/app/src/main/kotlin/com/example/calendar/data/CalendarDatabase.kt
+++ b/app/src/main/kotlin/com/example/calendar/data/CalendarDatabase.kt
@@ -1,0 +1,20 @@
+package com.example.calendar.data
+
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import androidx.room.TypeConverters
+
+@Database(
+    entities = [Task::class, CalendarEvent::class],
+    version = 1,
+    exportSchema = false
+)
+@TypeConverters(CalendarTypeConverters::class)
+abstract class CalendarDatabase : RoomDatabase() {
+    abstract fun taskDao(): TaskDao
+    abstract fun calendarEventDao(): CalendarEventDao
+
+    companion object {
+        const val DATABASE_NAME: String = "calendar.db"
+    }
+}

--- a/app/src/main/kotlin/com/example/calendar/data/CalendarEvent.kt
+++ b/app/src/main/kotlin/com/example/calendar/data/CalendarEvent.kt
@@ -1,9 +1,13 @@
 package com.example.calendar.data
 
+import androidx.room.Entity
+import androidx.room.PrimaryKey
 import java.time.LocalDateTime
 import java.util.UUID
 
+@Entity(tableName = "calendar_events")
 data class CalendarEvent(
+    @PrimaryKey
     val id: UUID = UUID.randomUUID(),
     val title: String,
     val description: String? = null,

--- a/app/src/main/kotlin/com/example/calendar/data/CalendarEventDao.kt
+++ b/app/src/main/kotlin/com/example/calendar/data/CalendarEventDao.kt
@@ -1,0 +1,31 @@
+package com.example.calendar.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+import java.time.LocalDateTime
+import java.util.UUID
+
+@Dao
+interface CalendarEventDao {
+    @Query(
+        "SELECT * FROM calendar_events WHERE start >= :start AND start < :end ORDER BY start"
+    )
+    fun observeEventsWithin(start: LocalDateTime, end: LocalDateTime): Flow<List<CalendarEvent>>
+
+    @Query(
+        "SELECT * FROM calendar_events WHERE start < :endExclusive AND end > :startInclusive ORDER BY start"
+    )
+    fun observeEventsIntersecting(
+        startInclusive: LocalDateTime,
+        endExclusive: LocalDateTime
+    ): Flow<List<CalendarEvent>>
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(event: CalendarEvent)
+
+    @Query("DELETE FROM calendar_events WHERE id = :id")
+    suspend fun deleteById(id: UUID)
+}

--- a/app/src/main/kotlin/com/example/calendar/data/CalendarTypeConverters.kt
+++ b/app/src/main/kotlin/com/example/calendar/data/CalendarTypeConverters.kt
@@ -1,0 +1,109 @@
+package com.example.calendar.data
+
+import androidx.room.TypeConverter
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.util.UUID
+
+class CalendarTypeConverters {
+    private val dateFormatter = DateTimeFormatter.ISO_LOCAL_DATE
+    private val dateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
+
+    @TypeConverter
+    fun fromUuid(value: UUID?): String? = value?.toString()
+
+    @TypeConverter
+    fun toUuid(value: String?): UUID? = value?.let(UUID::fromString)
+
+    @TypeConverter
+    fun fromLocalDate(value: LocalDate?): String? = value?.format(dateFormatter)
+
+    @TypeConverter
+    fun toLocalDate(value: String?): LocalDate? = value?.let { LocalDate.parse(it, dateFormatter) }
+
+    @TypeConverter
+    fun fromLocalDateTime(value: LocalDateTime?): String? = value?.format(dateTimeFormatter)
+
+    @TypeConverter
+    fun toLocalDateTime(value: String?): LocalDateTime? =
+        value?.let { LocalDateTime.parse(it, dateTimeFormatter) }
+
+    @TypeConverter
+    fun fromTaskStatus(value: TaskStatus?): String? = value?.name
+
+    @TypeConverter
+    fun toTaskStatus(value: String?): TaskStatus? = value?.let(TaskStatus::valueOf)
+
+    @TypeConverter
+    fun fromAgendaPeriod(value: AgendaPeriod?): String? = when (value) {
+        is AgendaPeriod.Day -> "DAY;${value.date.format(dateFormatter)}"
+        is AgendaPeriod.Week -> "WEEK;${value.start.format(dateFormatter)}"
+        is AgendaPeriod.Month -> "MONTH;${value.year};${value.month}"
+        null -> null
+    }
+
+    @TypeConverter
+    fun toAgendaPeriod(value: String?): AgendaPeriod? {
+        if (value.isNullOrBlank()) return null
+        val parts = value.split(';')
+        if (parts.isEmpty()) return null
+        return when (parts[0]) {
+            "DAY" -> parts.getOrNull(1)?.let { LocalDate.parse(it, dateFormatter) }?.let(AgendaPeriod::Day)
+            "WEEK" -> parts.getOrNull(1)?.let { LocalDate.parse(it, dateFormatter) }?.let(AgendaPeriod::Week)
+            "MONTH" -> {
+                val year = parts.getOrNull(1)?.toIntOrNull()
+                val month = parts.getOrNull(2)?.toIntOrNull()
+                if (year != null && month != null) AgendaPeriod.Month(year, month) else null
+            }
+            else -> null
+        }
+    }
+
+    @TypeConverter
+    fun fromReminders(value: List<Reminder>?): String? = value
+        ?.joinToString(separator = "|") { reminder ->
+            listOf(reminder.minutesBefore.toString(), if (reminder.allowSnooze) "1" else "0").joinToString(",")
+        }
+
+    @TypeConverter
+    fun toReminders(value: String?): List<Reminder> {
+        if (value.isNullOrBlank()) return emptyList()
+        return value.split('|').mapNotNull { entry ->
+            val parts = entry.split(',')
+            val minutes = parts.getOrNull(0)?.toLongOrNull() ?: return@mapNotNull null
+            val allowSnooze = parts.getOrNull(1)?.let { it == "1" || it.equals("true", ignoreCase = true) } ?: true
+            Reminder(minutesBefore = minutes, allowSnooze = allowSnooze)
+        }
+    }
+
+    @TypeConverter
+    fun fromTags(value: Set<String>?): String? = value?.joinToString(separator = "|")
+
+    @TypeConverter
+    fun toTags(value: String?): Set<String> {
+        if (value.isNullOrBlank()) return emptySet()
+        return value.split('|').mapNotNull { it.trim().takeIf(String::isNotEmpty) }.toSet()
+    }
+
+    @TypeConverter
+    fun fromRecurrence(value: Recurrence?): String? = value?.let {
+        buildString {
+            append(it.rule.name)
+            append(';')
+            append(it.interval)
+            append(';')
+            append(it.occurrences ?: "")
+        }
+    }
+
+    @TypeConverter
+    fun toRecurrence(value: String?): Recurrence? {
+        if (value.isNullOrBlank()) return null
+        val parts = value.split(';')
+        val rule = parts.getOrNull(0)?.let(RecurrenceRule::valueOf) ?: return null
+        val interval = parts.getOrNull(1)?.toIntOrNull() ?: 1
+        val occurrences = parts.getOrNull(2)?.takeIf { it.isNotBlank() }?.toIntOrNull()
+        return Recurrence(rule = rule, interval = interval, occurrences = occurrences)
+    }
+}

--- a/app/src/main/kotlin/com/example/calendar/data/RoomEventRepository.kt
+++ b/app/src/main/kotlin/com/example/calendar/data/RoomEventRepository.kt
@@ -1,0 +1,28 @@
+package com.example.calendar.data
+
+import java.time.LocalDate
+import java.util.UUID
+
+class RoomEventRepository(private val eventDao: CalendarEventDao) : EventRepository {
+    override fun observeEventsForDay(date: LocalDate) =
+        eventDao.observeEventsWithin(date.atStartOfDay(), date.plusDays(1).atStartOfDay())
+
+    override fun observeEventsForRange(start: LocalDate, end: LocalDate) =
+        eventDao.observeEventsIntersecting(
+            startInclusive = start.atStartOfDay(),
+            endExclusive = end.plusDays(1).atStartOfDay()
+        )
+
+    override suspend fun upsert(event: CalendarEvent) {
+        validateEvent(event)
+        eventDao.upsert(event)
+    }
+
+    override suspend fun delete(id: UUID) {
+        eventDao.deleteById(id)
+    }
+
+    private fun validateEvent(event: CalendarEvent) {
+        require(!event.end.isBefore(event.start)) { "Event end time must be after start time" }
+    }
+}

--- a/app/src/main/kotlin/com/example/calendar/data/RoomTaskRepository.kt
+++ b/app/src/main/kotlin/com/example/calendar/data/RoomTaskRepository.kt
@@ -1,0 +1,28 @@
+package com.example.calendar.data
+
+import java.time.LocalDate
+import java.util.UUID
+
+class RoomTaskRepository(private val taskDao: TaskDao) : TaskRepository {
+    override fun observeTasksForDay(date: LocalDate) =
+        taskDao.observeTasksByPeriod(AgendaPeriod.Day(date))
+
+    override fun observeTasksForWeek(start: LocalDate) =
+        taskDao.observeTasksByPeriod(AgendaPeriod.Week(start))
+
+    override fun observeTasksForMonth(year: Int, month: Int) =
+        taskDao.observeTasksByPeriod(AgendaPeriod.Month(year, month))
+
+    override suspend fun upsert(task: Task) {
+        taskDao.upsert(task)
+    }
+
+    override suspend fun toggleStatus(id: UUID) {
+        val existing = taskDao.findById(id) ?: return
+        taskDao.upsert(existing.toggleCompletion())
+    }
+
+    override suspend fun delete(id: UUID) {
+        taskDao.deleteById(id)
+    }
+}

--- a/app/src/main/kotlin/com/example/calendar/data/Task.kt
+++ b/app/src/main/kotlin/com/example/calendar/data/Task.kt
@@ -1,5 +1,8 @@
 package com.example.calendar.data
 
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
@@ -7,12 +10,15 @@ import java.util.UUID
 /**
  * Represents a to-do item that can appear within daily, weekly, or monthly agenda views.
  */
+@Entity(tableName = "tasks")
 data class Task(
+    @PrimaryKey
     val id: UUID = UUID.randomUUID(),
     val title: String,
     val description: String? = null,
     val status: TaskStatus = TaskStatus.Pending,
     val dueAt: LocalDateTime? = null,
+    @ColumnInfo(name = "period")
     val period: AgendaPeriod,
     val reminders: List<Reminder> = emptyList(),
     val tags: Set<String> = emptySet()

--- a/app/src/main/kotlin/com/example/calendar/data/TaskDao.kt
+++ b/app/src/main/kotlin/com/example/calendar/data/TaskDao.kt
@@ -1,0 +1,23 @@
+package com.example.calendar.data
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import kotlinx.coroutines.flow.Flow
+import java.util.UUID
+
+@Dao
+interface TaskDao {
+    @Query("SELECT * FROM tasks WHERE period = :period ORDER BY dueAt IS NULL, dueAt")
+    fun observeTasksByPeriod(period: AgendaPeriod): Flow<List<Task>>
+
+    @Query("SELECT * FROM tasks WHERE id = :id LIMIT 1")
+    suspend fun findById(id: UUID): Task?
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun upsert(task: Task)
+
+    @Query("DELETE FROM tasks WHERE id = :id")
+    suspend fun deleteById(id: UUID)
+}


### PR DESCRIPTION
## Summary
- add Room dependencies to the Android module build script
- convert Task and CalendarEvent models into Room entities with supporting DAO and database classes
- implement Room-backed repositories and type converters for agenda periods, reminders, and recurrence data

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68de01f810bc832dba9efcc02677a404