### PR TITLE
Integrate Android reminder scheduling

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,0 +1,60 @@
+import org.gradle.api.JavaVersion
+
+plugins {
+    id("com.android.application")
+    kotlin("android")
+    kotlin("kapt")
+}
+
+android {
+    namespace = "com.example.calendar"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.calendar"
+        minSdk = 26
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        getByName("release") {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("com.google.android.material:material:1.11.0")
+
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
+
+    implementation("androidx.work:work-runtime-ktx:2.9.0")
+    implementation("androidx.core:core-splashscreen:1.0.1")
+
+    implementation("androidx.compose.ui:ui:1.5.4")
+    implementation("androidx.compose.material3:material3:1.1.2")
+
+    testImplementation("junit:junit:4.13.2")
+    androidTestImplementation("androidx.test.ext:junit:1.1.5")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
+}

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Empty by default. Add project specific ProGuard rules here.

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" tools:targetApi="31" />
+
+    <application>
+        <receiver
+            android:name=".reminder.ReminderReceiver"
+            android:enabled="true"
+            android:exported="false" />
+    </application>
+
+</manifest>

--- a/app/src/main/kotlin/com/example/calendar/reminder/AndroidReminderScheduler.kt
+++ b/app/src/main/kotlin/com/example/calendar/reminder/AndroidReminderScheduler.kt
@@ -1,0 +1,97 @@
+package com.example.calendar.reminder
+
+import android.app.AlarmManager
+import android.content.Context
+import androidx.core.app.AlarmManagerCompat
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import com.example.calendar.data.Reminder
+import java.time.Clock
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+
+/**
+ * Concrete implementation of [ReminderScheduler] that integrates with Android's
+ * [AlarmManager] and Jetpack [WorkManager].
+ */
+class AndroidReminderScheduler(
+    private val context: Context,
+    private val alarmManager: AlarmManager,
+    private val workManager: WorkManager,
+    private val clock: Clock = Clock.systemDefaultZone(),
+    private val zoneId: ZoneId = clock.zone
+) : ReminderScheduler {
+
+    override fun scheduleReminder(
+        id: String,
+        triggerAt: LocalDateTime,
+        reminder: Reminder,
+        payload: ReminderPayload
+    ) {
+        val triggerAtMillis = triggerAt.toZonedDateTime().toInstant().toEpochMilli()
+        val requestCode = requestCodeFor(id)
+
+        val pendingIntent = ReminderReceiver.createPendingIntent(
+            context = context,
+            requestCode = requestCode,
+            id = id,
+            payload = payload
+        )
+
+        AlarmManagerCompat.setExactAndAllowWhileIdle(
+            alarmManager,
+            AlarmManager.RTC_WAKEUP,
+            triggerAtMillis,
+            pendingIntent
+        )
+
+        enqueueOneTimeWorker(id, payload, triggerAt)
+    }
+
+    override fun cancelReminder(id: String) {
+        val requestCode = requestCodeFor(id)
+        val pendingIntent = ReminderReceiver.createPendingIntent(
+            context = context,
+            requestCode = requestCode,
+            id = id,
+            payload = null
+        )
+
+        alarmManager.cancel(pendingIntent)
+        pendingIntent.cancel()
+
+        workManager.cancelUniqueWork(ReminderNotificationWorker.uniqueWorkName(id))
+    }
+
+    private fun enqueueOneTimeWorker(
+        id: String,
+        payload: ReminderPayload,
+        triggerAt: LocalDateTime
+    ) {
+        val delay = Duration.between(ZonedDateTime.now(clock), triggerAt.toZonedDateTime())
+            .coerceAtLeast(Duration.ZERO)
+
+        val workRequest = OneTimeWorkRequestBuilder<ReminderNotificationWorker>()
+            .setInitialDelay(delay)
+            .setInputData(ReminderNotificationWorker.createInputData(id, payload))
+            .addTag(ReminderNotificationWorker.tag(id))
+            .build()
+
+        workManager.enqueueUniqueWork(
+            ReminderNotificationWorker.uniqueWorkName(id),
+            ExistingWorkPolicy.REPLACE,
+            workRequest
+        )
+    }
+
+    private fun Duration.coerceAtLeast(min: Duration): Duration =
+        if (this < min) min else this
+
+    private fun LocalDateTime.toZonedDateTime(): ZonedDateTime =
+        atZone(zoneId)
+
+    private fun requestCodeFor(id: String): Int = id.hashCode()
+}

--- a/app/src/main/kotlin/com/example/calendar/reminder/ReminderNotificationWorker.kt
+++ b/app/src/main/kotlin/com/example/calendar/reminder/ReminderNotificationWorker.kt
@@ -1,0 +1,103 @@
+package com.example.calendar.reminder
+
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import androidx.core.app.NotificationCompat
+import androidx.core.app.NotificationManagerCompat
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.WorkerParameters
+
+/**
+ * [CoroutineWorker] responsible for showing reminder notifications when alarms fire.
+ */
+class ReminderNotificationWorker(
+    appContext: Context,
+    workerParams: WorkerParameters
+) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        val reminderId = inputData.getString(KEY_ID) ?: return Result.failure()
+        val title = inputData.getString(KEY_TITLE) ?: return Result.failure()
+        val message = inputData.getString(KEY_MESSAGE) ?: ""
+        val deepLink = inputData.getString(KEY_DEEP_LINK)
+        val allowSnooze = inputData.getBoolean(KEY_ALLOW_SNOOZE, false)
+
+        createNotificationChannel()
+
+        val contentIntent = deepLink?.let { link ->
+            PendingIntent.getActivity(
+                applicationContext,
+                reminderId.hashCode(),
+                Intent(Intent.ACTION_VIEW, Uri.parse(link)),
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+            )
+        }
+
+        val builder = NotificationCompat.Builder(applicationContext, CHANNEL_ID)
+            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .setContentTitle(title)
+            .setContentText(message)
+            .setAutoCancel(true)
+            .setPriority(NotificationCompat.PRIORITY_HIGH)
+
+        if (contentIntent != null) {
+            builder.setContentIntent(contentIntent)
+        }
+
+        if (allowSnooze) {
+            builder.setCategory(NotificationCompat.CATEGORY_REMINDER)
+        } else {
+            builder.setOnlyAlertOnce(true)
+        }
+
+        NotificationManagerCompat.from(applicationContext).notify(reminderId.hashCode(), builder.build())
+
+        return Result.success()
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+
+        val channel = NotificationChannel(
+            CHANNEL_ID,
+            CHANNEL_NAME,
+            NotificationManager.IMPORTANCE_HIGH
+        ).apply {
+            description = CHANNEL_DESCRIPTION
+        }
+
+        val manager = applicationContext.getSystemService(NotificationManager::class.java)
+        manager?.createNotificationChannel(channel)
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "calendar_reminders"
+        private const val CHANNEL_NAME = "Calendar reminders"
+        private const val CHANNEL_DESCRIPTION = "Notifications for scheduled calendar reminders"
+
+        private const val KEY_ID = "key_id"
+        private const val KEY_TITLE = "key_title"
+        private const val KEY_MESSAGE = "key_message"
+        private const val KEY_DEEP_LINK = "key_deep_link"
+        private const val KEY_ALLOW_SNOOZE = "key_allow_snooze"
+
+        fun createInputData(id: String, payload: ReminderPayload): Data =
+            Data.Builder()
+                .putString(KEY_ID, id)
+                .putString(KEY_TITLE, payload.title)
+                .putString(KEY_MESSAGE, payload.message)
+                .putString(KEY_DEEP_LINK, payload.deepLink)
+                .putBoolean(KEY_ALLOW_SNOOZE, payload.allowSnooze)
+                .build()
+
+        fun uniqueWorkName(id: String): String = "reminder-notification-$id"
+
+        fun tag(id: String): String = "reminder-tag-$id"
+    }
+}

--- a/app/src/main/kotlin/com/example/calendar/reminder/ReminderReceiver.kt
+++ b/app/src/main/kotlin/com/example/calendar/reminder/ReminderReceiver.kt
@@ -1,0 +1,86 @@
+package com.example.calendar.reminder
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+
+/**
+ * Broadcast receiver triggered by [AlarmManager] to enqueue the reminder notification work.
+ */
+class ReminderReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        val reminderId = intent.getStringExtra(EXTRA_ID) ?: return
+        val title = intent.getStringExtra(EXTRA_TITLE).orEmpty()
+        val message = intent.getStringExtra(EXTRA_MESSAGE).orEmpty()
+        val deepLink = intent.getStringExtra(EXTRA_DEEP_LINK).orEmpty()
+        val allowSnooze = intent.getBooleanExtra(EXTRA_ALLOW_SNOOZE, false)
+
+        val workRequest = OneTimeWorkRequestBuilder<ReminderNotificationWorker>()
+            .setInputData(
+                ReminderNotificationWorker.createInputData(
+                    id = reminderId,
+                    payload = ReminderPayload(
+                        title = title,
+                        message = message,
+                        deepLink = deepLink,
+                        allowSnooze = allowSnooze
+                    )
+                )
+            )
+            .addTag(ReminderNotificationWorker.tag(reminderId))
+            .build()
+
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            ReminderNotificationWorker.uniqueWorkName(reminderId),
+            ExistingWorkPolicy.REPLACE,
+            workRequest
+        )
+    }
+
+    companion object {
+        private const val ACTION_REMINDER = "com.example.calendar.action.SHOW_REMINDER"
+        private const val URI_SCHEME = "calendar"
+
+        private const val EXTRA_ID = "extra_id"
+        private const val EXTRA_TITLE = "extra_title"
+        private const val EXTRA_MESSAGE = "extra_message"
+        private const val EXTRA_DEEP_LINK = "extra_deep_link"
+        private const val EXTRA_ALLOW_SNOOZE = "extra_allow_snooze"
+
+        fun createPendingIntent(
+            context: Context,
+            requestCode: Int,
+            id: String,
+            payload: ReminderPayload?
+        ) = PendingIntentProvider.getBroadcast(
+            context = context,
+            requestCode = requestCode,
+            intent = Intent(context, ReminderReceiver::class.java).apply {
+                action = ACTION_REMINDER
+                data = Uri.parse("$URI_SCHEME://reminder/$id")
+                putExtra(EXTRA_ID, id)
+                if (payload != null) {
+                    putExtra(EXTRA_TITLE, payload.title)
+                    putExtra(EXTRA_MESSAGE, payload.message)
+                    putExtra(EXTRA_DEEP_LINK, payload.deepLink)
+                    putExtra(EXTRA_ALLOW_SNOOZE, payload.allowSnooze)
+                }
+            }
+        )
+    }
+}
+
+private object PendingIntentProvider {
+    fun getBroadcast(context: Context, requestCode: Int, intent: Intent) =
+        android.app.PendingIntent.getBroadcast(
+            context,
+            requestCode,
+            intent,
+            android.app.PendingIntent.FLAG_UPDATE_CURRENT or android.app.PendingIntent.FLAG_IMMUTABLE
+        )
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,0 +1,17 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.2.2")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.22")
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "CalendarPlanner"
+
+include(":app")


### PR DESCRIPTION
## Summary
- add an Android-specific reminder scheduler backed by AlarmManager and WorkManager
- enqueue reminder notifications through a broadcast receiver and coroutine worker with notification channel support
- configure Gradle and manifest entries with lifecycle, WorkManager, and alarm permissions for the calendar module

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de01efb8ec832d8eaaf24aeb9903a5