### PR TITLE
Fix agenda flow cancellation and reminder cleanup

### DIFF
--- a/app/src/main/kotlin/com/example/calendar/reminder/ReminderOrchestrator.kt
+++ b/app/src/main/kotlin/com/example/calendar/reminder/ReminderOrchestrator.kt
@@ -34,8 +34,19 @@ class ReminderOrchestrator(
         )
     }
 
-    fun cancelForTask(task: Task) = scheduler.cancelReminder("task-${task.id}")
-    fun cancelForEvent(event: CalendarEvent) = scheduler.cancelReminder("event-${event.id}")
+    fun cancelForTask(task: Task) {
+        cancelScheduledReminders(
+            baseId = "task-${task.id}",
+            reminders = task.reminders
+        )
+    }
+
+    fun cancelForEvent(event: CalendarEvent) {
+        cancelScheduledReminders(
+            baseId = "event-${event.id}",
+            reminders = event.reminders
+        )
+    }
 
     private fun scheduleReminders(
         baseId: String,
@@ -61,6 +72,15 @@ class ReminderOrchestrator(
                     )
                 )
             }
+        }
+    }
+
+    private fun cancelScheduledReminders(
+        baseId: String,
+        reminders: List<Reminder>
+    ) {
+        reminders.indices.forEach { index ->
+            scheduler.cancelReminder("$baseId-$index")
         }
     }
 }

--- a/app/src/main/kotlin/com/example/calendar/ui/AgendaViewModel.kt
+++ b/app/src/main/kotlin/com/example/calendar/ui/AgendaViewModel.kt
@@ -10,6 +10,7 @@ import com.example.calendar.reminder.ReminderOrchestrator
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
@@ -45,17 +46,18 @@ class AgendaViewModel(
     }
 
     private fun observePeriod() {
-        _period.onEach { period ->
-            aggregator.observeAgenda(period)
-                .onEach { snapshot ->
-                    _state.value = _state.value.copy(
-                        snapshot = snapshot,
-                        isLoading = false,
-                        error = null
-                    )
-                }
-                .launchIn(viewModelScope)
-        }.launchIn(viewModelScope)
+        _period
+            .flatMapLatest { period ->
+                aggregator.observeAgenda(period)
+            }
+            .onEach { snapshot ->
+                _state.value = _state.value.copy(
+                    snapshot = snapshot,
+                    isLoading = false,
+                    error = null
+                )
+            }
+            .launchIn(viewModelScope)
     }
 }
 


### PR DESCRIPTION
## Summary
- swap the agenda period observer to use flatMapLatest so stale collectors are cancelled when the period changes
- cancel every generated reminder id for tasks and events to align with scheduled suffixes

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68ec8c7545e0832db6515b7d2c7890f3