### PR TITLE
Add Android application entry point and dependency container

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -38,6 +38,14 @@ android {
     kotlinOptions {
         jvmTarget = "17"
     }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.7"
+    }
 }
 
 dependencies {
@@ -47,12 +55,27 @@ dependencies {
 
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.7.0")
 
     implementation("androidx.work:work-runtime-ktx:2.9.0")
     implementation("androidx.core:core-splashscreen:1.0.1")
 
-    implementation("androidx.compose.ui:ui:1.5.4")
-    implementation("androidx.compose.material3:material3:1.1.2")
+    implementation(platform("androidx.compose:compose-bom:2024.02.01"))
+    implementation("androidx.activity:activity-compose:1.8.2")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.foundation:foundation")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+    androidTestImplementation(platform("androidx.compose:compose-bom:2024.02.01"))
+    androidTestImplementation("androidx.compose.ui:ui-test-junit4")
+
+    implementation("androidx.room:room-runtime:2.6.1")
+    implementation("androidx.room:room-ktx:2.6.1")
+    kapt("androidx.room:room-compiler:2.6.1")
+
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
 
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,7 +5,22 @@
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM" tools:targetApi="31" />
 
-    <application>
+    <application
+        android:name=".CalendarApplication"
+        android:allowBackup="true"
+        android:label="@string/app_name"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.Material3.DayNight.NoActionBar">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:theme="@style/Theme.Material3.DayNight.NoActionBar">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
         <receiver
             android:name=".reminder.ReminderReceiver"
             android:enabled="true"

--- a/app/src/main/kotlin/com/example/calendar/CalendarApplication.kt
+++ b/app/src/main/kotlin/com/example/calendar/CalendarApplication.kt
@@ -1,0 +1,76 @@
+package com.example.calendar
+
+import android.app.AlarmManager
+import android.app.Application
+import android.content.Context
+import androidx.room.Room
+import androidx.work.WorkManager
+import com.example.calendar.data.CalendarDatabase
+import com.example.calendar.data.EventRepository
+import com.example.calendar.data.RoomEventRepository
+import com.example.calendar.data.RoomTaskRepository
+import com.example.calendar.data.TaskRepository
+import com.example.calendar.reminder.AndroidReminderScheduler
+import com.example.calendar.reminder.ReminderOrchestrator
+import com.example.calendar.reminder.ReminderScheduler
+import com.example.calendar.scheduler.AgendaAggregator
+
+class CalendarApplication : Application() {
+    lateinit var container: AppContainer
+        private set
+
+    override fun onCreate() {
+        super.onCreate()
+        container = DefaultAppContainer(this)
+    }
+}
+
+interface AppContainer {
+    val taskRepository: TaskRepository
+    val eventRepository: EventRepository
+    val reminderOrchestrator: ReminderOrchestrator
+    val agendaAggregator: AgendaAggregator
+}
+
+private class DefaultAppContainer(private val context: Context) : AppContainer {
+    private val database: CalendarDatabase by lazy {
+        Room.databaseBuilder(
+            context,
+            CalendarDatabase::class.java,
+            CalendarDatabase.DATABASE_NAME
+        ).fallbackToDestructiveMigration().build()
+    }
+
+    private val alarmManager: AlarmManager by lazy {
+        context.getSystemService(AlarmManager::class.java)
+            ?: throw IllegalStateException("AlarmManager not available")
+    }
+
+    private val workManager: WorkManager by lazy {
+        WorkManager.getInstance(context)
+    }
+
+    private val reminderScheduler: ReminderScheduler by lazy {
+        AndroidReminderScheduler(
+            context = context,
+            alarmManager = alarmManager,
+            workManager = workManager
+        )
+    }
+
+    override val taskRepository: TaskRepository by lazy {
+        RoomTaskRepository(database.taskDao())
+    }
+
+    override val eventRepository: EventRepository by lazy {
+        RoomEventRepository(database.calendarEventDao())
+    }
+
+    override val reminderOrchestrator: ReminderOrchestrator by lazy {
+        ReminderOrchestrator(reminderScheduler)
+    }
+
+    override val agendaAggregator: AgendaAggregator by lazy {
+        AgendaAggregator(taskRepository, eventRepository)
+    }
+}

--- a/app/src/main/kotlin/com/example/calendar/MainActivity.kt
+++ b/app/src/main/kotlin/com/example/calendar/MainActivity.kt
@@ -1,0 +1,26 @@
+package com.example.calendar
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import com.example.calendar.ui.AgendaViewModel
+import com.example.calendar.ui.AgendaViewModelFactory
+import com.example.calendar.ui.CalendarApp
+
+class MainActivity : ComponentActivity() {
+    private val viewModel: AgendaViewModel by viewModels {
+        val app = application as CalendarApplication
+        AgendaViewModelFactory(
+            aggregator = app.container.agendaAggregator,
+            reminderOrchestrator = app.container.reminderOrchestrator
+        )
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            CalendarApp(viewModel = viewModel)
+        }
+    }
+}

--- a/app/src/main/kotlin/com/example/calendar/ui/AgendaViewModelFactory.kt
+++ b/app/src/main/kotlin/com/example/calendar/ui/AgendaViewModelFactory.kt
@@ -1,0 +1,19 @@
+package com.example.calendar.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.calendar.reminder.ReminderOrchestrator
+import com.example.calendar.scheduler.AgendaAggregator
+
+class AgendaViewModelFactory(
+    private val aggregator: AgendaAggregator,
+    private val reminderOrchestrator: ReminderOrchestrator
+) : ViewModelProvider.Factory {
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(AgendaViewModel::class.java)) {
+            return AgendaViewModel(aggregator, reminderOrchestrator) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class: ${'$'}{modelClass.name}")
+    }
+}

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Work01 Calendar</string>
+</resources>


### PR DESCRIPTION
## Summary
- enable Jetpack Compose in the Gradle configuration and add Room, coroutine, and Compose dependencies
- introduce an application-level container that wires Room repositories with the reminder scheduler and agenda aggregator
- add a Compose-driven MainActivity that hosts the calendar UI via the AgendaViewModel

## Testing
- not run (Gradle wrapper is not present in the repository)


------
https://chatgpt.com/codex/tasks/task_e_68ec8ac4109c832db8cc1a2c2809eaa9