### PR TITLE
Wire Android reminders and permission prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ These files are intended as a foundation for a full Android Studio project.
   **Compose 셸** – `CalendarApp`과 `AgendaRoute`가 탭, 리스트 스캐폴드, 스와이프 완료 행, 상세 시트를 뷰모델과 연동합니다.
 - **Unit tests** – Aggregator, reminder orchestration, and `AgendaViewModel` tests validate core scheduling logic.
   **단위 테스트** – 애그리게이터, 알림 오케스트레이터, `AgendaViewModel` 테스트로 핵심 스케줄링 로직을 검증합니다.
+- **Quick add flow** – The floating action button launches a sheet to capture new tasks or events with default dates.
+  **빠른 추가 플로우** – 플로팅 액션 버튼으로 시트를 열어 기본 날짜와 함께 일정·할 일을 즉시 등록할 수 있습니다.
+- **Reminder orchestration** – `ReminderOrchestrator` now drives `AndroidReminderScheduler`, wiring AlarmManager/WorkManager alarms and an in-app notification permission prompt.
+  **알림 오케스트레이션** – `ReminderOrchestrator`가 `AndroidReminderScheduler`와 연결되어 AlarmManager/WorkManager 알람을 예약하고 앱 내 알림 권한 안내를 제공합니다.
 
 ### Partially done (부분 완료)
 - **Interactive UI polish** – Agenda detail sheet toggles and swipe actions are present, but require QA and accessibility review.
@@ -55,10 +59,6 @@ These files are intended as a foundation for a full Android Studio project.
   **품질 도구** – ViewModel/도메인 테스트는 있으나 Compose 프리뷰와 UI 테스트는 없습니다.
 
 ### Not yet implemented (미구현)
-- **Quick add flow** – The FAB surface is exposed but no quick-add sheet or handlers are wired, preventing in-app creation.
-  **빠른 추가 플로우** – FAB은 존재하지만 시트/핸들러가 없어 앱 내 생성이 불가합니다.
-- **Real reminder scheduling** – `ReminderOrchestrator` still targets a `NoOpReminderScheduler`; Android alarm integration and permission prompts remain.
-  **실제 알림 스케줄링** – `ReminderOrchestrator`가 여전히 `NoOpReminderScheduler`에 연결되어 있어 알람 통합과 권한 흐름이 남아 있습니다.
 - **Gradle wrapper & CI** – The project cannot run automated builds until the Gradle wrapper and CI tasks are configured.
   **Gradle 래퍼 & CI** – Gradle 래퍼와 CI 작업을 구성해야 자동 빌드가 가능합니다.
 
@@ -67,13 +67,13 @@ These files are intended as a foundation for a full Android Studio project.
 | --- | --- | --- | --- |
 | P0 | Compose agenda layout polish (tabs, empty states, list accessibility) / Compose 일정 화면 세부 다듬기 | ✅ Skeleton in place, needs UX polish. / 뼈대 완료, UX 다듬기 필요 |
 | P0 | Agenda detail bottom sheet / 일정·할 일 상세 시트 | ✅ Opens with toggle/delete hooks; finalize flows. / 열림 및 토글/삭제 훅 존재, 플로우 마무리 필요 |
-| P0 | Quick add FAB workflow / 새 항목 빠른 추가 | 🚧 Missing handlers, implement quick-add sheet. / 핸들러 미구현, 빠른 추가 시트 작성 |
-| P1 | Reminder orchestration hand-off / 알림 연동 준비 | 🚧 Wire real scheduler & permissions. / 실제 스케줄러 및 권한 연동 |
+| P0 | Quick add FAB workflow / 새 항목 빠른 추가 | ✅ FAB opens quick-add sheet for tasks & events. / FAB으로 일정·할 일을 즉시 추가 |
+| P1 | Reminder orchestration hand-off / 알림 연동 준비 | ✅ AlarmManager·WorkManager 연결 및 권한 안내 완료. |
 | P1 | Testing & previews / 테스트·프리뷰 추가 | 🚧 Add Compose previews + UI tests. / Compose 프리뷰·UI 테스트 추가 |
 
 ### Additional backlog (추가 백로그)
-- Connect WorkManager/AlarmManager for recurring reminders and exact alarms.
-  WorkManager/AlarmManager를 연결해 반복/정시 알람을 구현합니다.
+- Expand reminder cadence and snooze actions on top of the AlarmManager/WorkManager integration.
+  AlarmManager/WorkManager 연동 위에 반복 주기와 스누즈 동작을 확장합니다.
 - Fill out Android resources (strings, themes, navigation graph) and internationalization.
   문자열, 테마, 내비게이션 그래프 및 다국어 리소스를 채워 넣습니다.
 - Investigate backup/sync strategies once local persistence is stable.

--- a/app/src/main/kotlin/com/example/calendar/CalendarApplication.kt
+++ b/app/src/main/kotlin/com/example/calendar/CalendarApplication.kt
@@ -12,7 +12,7 @@ class CalendarApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        container = QuickStartAppContainer()
+        container = QuickStartAppContainer(applicationContext)
     }
 }
 

--- a/app/src/main/kotlin/com/example/calendar/ui/CalendarApp.kt
+++ b/app/src/main/kotlin/com/example/calendar/ui/CalendarApp.kt
@@ -1,6 +1,45 @@
 package com.example.calendar.ui
 
+import android.Manifest
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.provider.Settings
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.weight
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import com.example.calendar.data.CalendarEvent
 import com.example.calendar.data.Task
 import com.example.calendar.ui.agenda.AgendaRoute
@@ -13,10 +52,180 @@ fun CalendarApp(
     onTaskClick: (Task) -> Unit = {}
 ) {
     CalendarTheme {
+        val permissionController = rememberNotificationPermissionController()
+        var dismissed by rememberSaveable { mutableStateOf(false) }
+
+        LaunchedEffect(permissionController.shouldShowPrompt) {
+            if (!permissionController.shouldShowPrompt) {
+                dismissed = false
+            }
+        }
+
+        val notificationCard: (@Composable () -> Unit)? = if (permissionController.shouldShowPrompt && !dismissed) {
+            {
+                NotificationPermissionCard(
+                    controller = permissionController,
+                    onDismiss = { dismissed = true },
+                    modifier = Modifier
+                        .padding(horizontal = 16.dp, vertical = 12.dp)
+                )
+            }
+        } else {
+            null
+        }
+
         AgendaRoute(
             viewModel = viewModel,
             onEventClick = onEventClick,
-            onTaskClick = onTaskClick
+            onTaskClick = onTaskClick,
+            notificationPermissionCard = notificationCard
         )
     }
+}
+
+@Composable
+private fun NotificationPermissionCard(
+    controller: NotificationPermissionController,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        tonalElevation = 6.dp
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp)
+        ) {
+            Text(
+                text = "알림 권한을 허용해 주세요",
+                style = MaterialTheme.typography.titleMedium
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = if (controller.canRequest) {
+                    "리마인더를 켜 두면 일정이나 할 일을 추가할 때 시작 전에 알림을 받을 수 있어요."
+                } else {
+                    "앱 설정에서 알림을 허용하면 일정 전에 리마인더를 받을 수 있어요."
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                TextButton(onClick = onDismiss) {
+                    Text(text = "나중에")
+                }
+                Spacer(modifier = Modifier.weight(1f))
+                val actionLabel = if (controller.canRequest) "알림 허용" else "설정 열기"
+                Button(
+                    onClick = {
+                        if (controller.canRequest) {
+                            controller.requestPermission()
+                        } else {
+                            controller.openSettings()
+                        }
+                    }
+                ) {
+                    Text(text = actionLabel)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun rememberNotificationPermissionController(): NotificationPermissionController {
+    val context = LocalContext.current
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val isSupported = Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU
+
+    var hasRequested by rememberSaveable { mutableStateOf(false) }
+    var isGranted by remember { mutableStateOf(hasNotificationPermission(context)) }
+
+    val launcher = rememberLauncherForActivityResult(ActivityResultContracts.RequestPermission()) { granted ->
+        hasRequested = true
+        isGranted = granted || !isSupported
+    }
+
+    DisposableEffect(lifecycleOwner, context, isSupported) {
+        if (!isSupported) {
+            return@DisposableEffect onDispose {}
+        }
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                isGranted = hasNotificationPermission(context)
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
+
+    LaunchedEffect(context, isSupported) {
+        if (isSupported) {
+            isGranted = hasNotificationPermission(context)
+        }
+    }
+
+    val activity = remember(context) { context.findActivity() }
+    val canRequest = isSupported && !isGranted && (!hasRequested || activity?.let {
+        ActivityCompat.shouldShowRequestPermissionRationale(it, Manifest.permission.POST_NOTIFICATIONS)
+    } == true)
+
+    return NotificationPermissionController(
+        isSupported = isSupported,
+        isGranted = isGranted,
+        canRequest = canRequest,
+        requestPermission = {
+            if (isSupported && !isGranted) {
+                hasRequested = true
+                launcher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            }
+        },
+        openSettings = {
+            if (!isGranted && isSupported) {
+                openNotificationSettings(context)
+            }
+        }
+    )
+}
+
+private data class NotificationPermissionController(
+    val isSupported: Boolean,
+    val isGranted: Boolean,
+    val canRequest: Boolean,
+    val requestPermission: () -> Unit,
+    val openSettings: () -> Unit
+) {
+    val shouldShowPrompt: Boolean
+        get() = isSupported && !isGranted
+}
+
+private fun hasNotificationPermission(context: Context): Boolean {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+        return true
+    }
+    return ContextCompat.checkSelfPermission(
+        context,
+        Manifest.permission.POST_NOTIFICATIONS
+    ) == PackageManager.PERMISSION_GRANTED
+}
+
+private fun openNotificationSettings(context: Context) {
+    val intent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+        putExtra(Settings.EXTRA_APP_PACKAGE, context.packageName)
+        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    context.startActivity(intent)
+}
+
+private tailrec fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
 }

--- a/app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt
+++ b/app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt
@@ -30,7 +30,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -42,7 +46,6 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.material3.rememberSwipeToDismissBoxState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -68,9 +71,12 @@ import com.example.calendar.data.Task
 import com.example.calendar.data.TaskStatus
 import com.example.calendar.scheduler.AgendaSnapshot
 import com.example.calendar.ui.AgendaUiState
+import com.example.calendar.ui.AgendaUserMessage
 import com.example.calendar.ui.AgendaViewModel
+import com.example.calendar.ui.QuickAddType
 import java.time.DayOfWeek
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.YearMonth
 import java.time.format.DateTimeFormatter
 import java.time.format.TextStyle
@@ -92,7 +98,8 @@ fun AgendaRoute(
     onEventClick: (CalendarEvent) -> Unit = {},
     onTaskClick: (Task) -> Unit = {},
     onEventEdit: (CalendarEvent) -> Unit = {},
-    onTaskEdit: (Task) -> Unit = {}
+    onTaskEdit: (Task) -> Unit = {},
+    notificationPermissionCard: (@Composable () -> Unit)? = null
 ) {
     val uiState by viewModel.state.collectAsState()
 
@@ -174,6 +181,7 @@ fun AgendaRoute(
                         hideSheet()
                     }
                 }
+                is AgendaSheetContent.QuickAdd -> Unit
             }
         }
     }
@@ -221,7 +229,16 @@ fun AgendaRoute(
             navigationState.navigateTo(AgendaTab.Daily)
         },
         focusedDay = focusedDay,
-        period = currentPeriod
+        period = currentPeriod,
+        onQuickAddClick = {
+            sheetContent = AgendaSheetContent.QuickAdd(
+                initialType = QuickAddType.Task,
+                focusDate = focusedDay,
+                period = currentPeriod
+            )
+        },
+        onUserMessageShown = viewModel::clearUserMessage,
+        notificationPrompt = notificationPermissionCard
     )
 
     sheetContent?.let { content ->
@@ -229,30 +246,64 @@ fun AgendaRoute(
             onDismissRequest = hideSheet,
             sheetState = sheetState
         ) {
-            AgendaDetailSheet(
-                content = content,
-                onToggleTask = { task ->
-                    viewModel.toggleTask(task)
-                    sheetContent = AgendaSheetContent.TaskDetail(task.toggleCompletion())
-                },
-                onDeleteTask = { task ->
-                    viewModel.deleteTask(task)
-                    hideSheet()
-                },
-                onDeleteEvent = { event ->
-                    viewModel.deleteEvent(event)
-                    hideSheet()
-                },
-                onEditTask = { task ->
-                    onTaskEdit(task)
-                    hideSheet()
-                },
-                onEditEvent = { event ->
-                    onEventEdit(event)
-                    hideSheet()
-                },
-                onClose = hideSheet
-            )
+            when (content) {
+                is AgendaSheetContent.TaskDetail -> TaskDetailSheet(
+                    task = content.task,
+                    onToggleTask = { task ->
+                        viewModel.toggleTask(task)
+                        sheetContent = AgendaSheetContent.TaskDetail(task.toggleCompletion())
+                    },
+                    onDeleteTask = {
+                        viewModel.deleteTask(it)
+                        hideSheet()
+                    },
+                    onEditTask = {
+                        onTaskEdit(it)
+                        hideSheet()
+                    },
+                    onClose = hideSheet
+                )
+                is AgendaSheetContent.EventDetail -> EventDetailSheet(
+                    event = content.event,
+                    onDeleteEvent = {
+                        viewModel.deleteEvent(it)
+                        hideSheet()
+                    },
+                    onEditEvent = {
+                        onEventEdit(it)
+                        hideSheet()
+                    },
+                    onClose = hideSheet
+                )
+                is AgendaSheetContent.QuickAdd -> QuickAddSheet(
+                    content = content,
+                    onCreateTask = { input ->
+                        viewModel
+                            .quickAddTask(
+                                title = input.title,
+                                focusDate = content.focusDate,
+                                period = content.period,
+                                description = input.notes,
+                                dueTime = input.dueTime
+                            )
+                            .map {}
+                    },
+                    onCreateEvent = { input ->
+                        viewModel
+                            .quickAddEvent(
+                                title = input.title,
+                                focusDate = content.focusDate,
+                                period = content.period,
+                                description = input.notes,
+                                location = input.location,
+                                startTime = input.startTime,
+                                endTime = input.endTime
+                            )
+                            .map {}
+                    },
+                    onDismiss = hideSheet
+                )
+            }
         }
     }
 
@@ -297,9 +348,25 @@ fun AgendaScreen(
     focusedDay: LocalDate,
     period: AgendaPeriod,
     onQuickAddClick: () -> Unit = {},
+    onUserMessageShown: () -> Unit = {},
+    notificationPrompt: (@Composable () -> Unit)? = null,
     modifier: Modifier = Modifier
 ) {
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(uiState.userMessage) {
+        uiState.userMessage?.let { message ->
+            snackbarHostState.showSnackbar(
+                message = message.toSnackbarMessage(),
+                withDismissAction = true,
+                duration = SnackbarDuration.Short
+            )
+            onUserMessageShown()
+        }
+    }
+
     Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         floatingActionButton = {
             AgendaFab(onClick = onQuickAddClick)
         },
@@ -342,6 +409,10 @@ fun AgendaScreen(
                     )
                     else -> AgendaEmptyState()
                 }
+            }
+            if (notificationPrompt != null) {
+                Spacer(modifier = Modifier.height(16.dp))
+                notificationPrompt()
             }
         }
     )
@@ -1018,33 +1089,11 @@ private fun TaskStatusBadge(status: TaskStatus) {
 private sealed interface AgendaSheetContent {
     data class TaskDetail(val task: Task) : AgendaSheetContent
     data class EventDetail(val event: CalendarEvent) : AgendaSheetContent
-}
-
-@Composable
-private fun AgendaDetailSheet(
-    content: AgendaSheetContent,
-    onToggleTask: (Task) -> Unit,
-    onDeleteTask: (Task) -> Unit,
-    onDeleteEvent: (CalendarEvent) -> Unit,
-    onEditTask: (Task) -> Unit,
-    onEditEvent: (CalendarEvent) -> Unit,
-    onClose: () -> Unit
-) {
-    when (content) {
-        is AgendaSheetContent.TaskDetail -> TaskDetailSheet(
-            task = content.task,
-            onToggleTask = onToggleTask,
-            onDeleteTask = onDeleteTask,
-            onEditTask = onEditTask,
-            onClose = onClose
-        )
-        is AgendaSheetContent.EventDetail -> EventDetailSheet(
-            event = content.event,
-            onDeleteEvent = onDeleteEvent,
-            onEditEvent = onEditEvent,
-            onClose = onClose
-        )
-    }
+    data class QuickAdd(
+        val initialType: QuickAddType,
+        val focusDate: LocalDate,
+        val period: AgendaPeriod
+    ) : AgendaSheetContent
 }
 
 @Composable
@@ -1159,6 +1208,237 @@ private fun EventDetailSheet(
     }
 }
 
+@Composable
+private fun QuickAddSheet(
+    content: AgendaSheetContent.QuickAdd,
+    onCreateTask: suspend (QuickAddTaskInput) -> Result<Unit>,
+    onCreateEvent: suspend (QuickAddEventInput) -> Result<Unit>,
+    onDismiss: () -> Unit
+) {
+    var selectedType by rememberSaveable { mutableStateOf(content.initialType) }
+    var taskTitle by rememberSaveable { mutableStateOf("") }
+    var taskNotes by rememberSaveable { mutableStateOf("") }
+    var taskTime by rememberSaveable { mutableStateOf(DEFAULT_TASK_TIME_TEXT) }
+
+    var eventTitle by rememberSaveable { mutableStateOf("") }
+    var eventLocation by rememberSaveable { mutableStateOf("") }
+    var eventNotes by rememberSaveable { mutableStateOf("") }
+    var eventStartTime by rememberSaveable { mutableStateOf(DEFAULT_EVENT_START_TEXT) }
+    var eventEndTime by rememberSaveable { mutableStateOf(DEFAULT_EVENT_END_TEXT) }
+
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+    var isSaving by remember { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
+
+    LaunchedEffect(selectedType) {
+        errorMessage = null
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = "빠른 추가",
+            style = MaterialTheme.typography.titleLarge
+        )
+        Text(
+            text = "${periodSummary(content.period)} · ${content.focusDate.format(DayFormatter)}",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            FilterChip(
+                selected = selectedType == QuickAddType.Task,
+                onClick = { selectedType = QuickAddType.Task },
+                label = { Text("할 일") }
+            )
+            FilterChip(
+                selected = selectedType == QuickAddType.Event,
+                onClick = { selectedType = QuickAddType.Event },
+                label = { Text("일정") }
+            )
+        }
+
+        when (selectedType) {
+            QuickAddType.Task -> {
+                OutlinedTextField(
+                    value = taskTitle,
+                    onValueChange = { taskTitle = it },
+                    label = { Text("제목") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = taskNotes,
+                    onValueChange = { taskNotes = it },
+                    label = { Text("메모 (선택)") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = taskTime,
+                    onValueChange = { taskTime = it },
+                    label = { Text("마감 시간 (HH:mm)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                    supportingText = {
+                        Text(
+                            text = "비워 두면 시간 없이 저장됩니다.",
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                )
+            }
+            QuickAddType.Event -> {
+                OutlinedTextField(
+                    value = eventTitle,
+                    onValueChange = { eventTitle = it },
+                    label = { Text("제목") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = eventLocation,
+                    onValueChange = { eventLocation = it },
+                    label = { Text("위치 (선택)") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = eventStartTime,
+                    onValueChange = { eventStartTime = it },
+                    label = { Text("시작 시간 (HH:mm)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = eventEndTime,
+                    onValueChange = { eventEndTime = it },
+                    label = { Text("종료 시간 (HH:mm)") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth()
+                )
+                OutlinedTextField(
+                    value = eventNotes,
+                    onValueChange = { eventNotes = it },
+                    label = { Text("메모 (선택)") },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+
+        errorMessage?.let { message ->
+            Text(
+                text = message,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.End)
+        ) {
+            TextButton(onClick = {
+                if (!isSaving) {
+                    onDismiss()
+                }
+            }) {
+                Text("취소")
+            }
+            Button(
+                onClick = {
+                    if (isSaving) return@Button
+                    errorMessage = null
+                    when (selectedType) {
+                        QuickAddType.Task -> {
+                            val title = taskTitle.trim()
+                            if (title.isEmpty()) {
+                                errorMessage = "제목을 입력해 주세요."
+                                return@Button
+                            }
+                            val dueTimeResult = taskTime.takeIf { it.isNotBlank() }?.let { value ->
+                                parseInputTime(value).onFailure {
+                                    errorMessage = "시간 형식은 HH:mm 이어야 해요."
+                                }
+                            }
+                            if (errorMessage != null) return@Button
+
+                            val dueTimeValue = dueTimeResult?.getOrNull()
+
+                            coroutineScope.launch {
+                                isSaving = true
+                                val result = onCreateTask(
+                                    QuickAddTaskInput(
+                                        title = title,
+                                        notes = taskNotes.takeIf { it.isNotBlank() },
+                                        dueTime = dueTimeValue
+                                    )
+                                )
+                                if (result.isSuccess) {
+                                    onDismiss()
+                                } else {
+                                    errorMessage = result.exceptionOrNull()?.message
+                                        ?: "저장에 실패했습니다."
+                                }
+                                isSaving = false
+                            }
+                        }
+                        QuickAddType.Event -> {
+                            val title = eventTitle.trim()
+                            if (title.isEmpty()) {
+                                errorMessage = "제목을 입력해 주세요."
+                                return@Button
+                            }
+                            val startResult = parseInputTime(eventStartTime).onFailure {
+                                errorMessage = "시작 시간을 HH:mm 형식으로 입력하세요."
+                            }
+                            if (errorMessage != null) return@Button
+                            val endResult = parseInputTime(eventEndTime).onFailure {
+                                errorMessage = "종료 시간을 HH:mm 형식으로 입력하세요."
+                            }
+                            if (errorMessage != null) return@Button
+
+                            val startValue = startResult.getOrNull()
+                            val endValue = endResult.getOrNull()
+                            if (startValue == null || endValue == null) {
+                                errorMessage = "시간을 다시 확인해 주세요."
+                                return@Button
+                            }
+
+                            coroutineScope.launch {
+                                isSaving = true
+                                val result = onCreateEvent(
+                                    QuickAddEventInput(
+                                        title = title,
+                                        location = eventLocation.takeIf { it.isNotBlank() },
+                                        notes = eventNotes.takeIf { it.isNotBlank() },
+                                        startTime = startValue,
+                                        endTime = endValue
+                                    )
+                                )
+                                if (result.isSuccess) {
+                                    onDismiss()
+                                } else {
+                                    errorMessage = result.exceptionOrNull()?.message
+                                        ?: "저장에 실패했습니다."
+                                }
+                                isSaving = false
+                            }
+                        }
+                    }
+                },
+                enabled = !isSaving
+            ) {
+                Text(if (isSaving) "저장 중..." else "저장")
+            }
+        }
+    }
+}
+
 
 
 @Composable
@@ -1208,6 +1488,14 @@ private fun eventTimeRange(event: CalendarEvent): String {
     }
 }
 
+private fun AgendaUserMessage.toSnackbarMessage(): String = when (this) {
+    is AgendaUserMessage.QuickAddSuccess -> when (type) {
+        QuickAddType.Task -> "할 일을 추가했어요."
+        QuickAddType.Event -> "일정을 추가했어요."
+    }
+    is AgendaUserMessage.QuickAddFailure -> reason
+}
+
 private fun AgendaTab.displayLabel(): String = when (this) {
     AgendaTab.Daily -> "Daily"
     AgendaTab.Weekly -> "Weekly"
@@ -1231,6 +1519,29 @@ private fun periodLabel(period: AgendaPeriod): String = when (period) {
         YearMonth.of(period.year, period.month).atDay(1)
     )
 }
+
+private data class QuickAddTaskInput(
+    val title: String,
+    val notes: String?,
+    val dueTime: LocalTime?
+)
+
+private data class QuickAddEventInput(
+    val title: String,
+    val location: String?,
+    val notes: String?,
+    val startTime: LocalTime,
+    val endTime: LocalTime
+)
+
+private fun parseInputTime(value: String): Result<LocalTime> {
+    return runCatching { LocalTime.parse(value.trim(), QuickAddTimeFormatter) }
+}
+
+private const val DEFAULT_TASK_TIME_TEXT = "09:00"
+private const val DEFAULT_EVENT_START_TEXT = "09:00"
+private const val DEFAULT_EVENT_END_TEXT = "10:00"
+private val QuickAddTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("H:mm", Locale.getDefault())
 
 private fun LocalDate.startOfWeek(): LocalDate {
     var date = this

--- a/docs/next-steps.md
+++ b/docs/next-steps.md
@@ -19,15 +19,15 @@
 3. [x] **입력 및 저장**
    - [x] 빠른 추가 FAB를 통해 최소 입력값만으로 이벤트/할 일을 생성합니다.
    - [x] 저장 성공/실패를 스낵바와 인라인 검증으로 안내합니다.
-4. [ ] **알림 연결 준비**
-   - [ ] `ReminderOrchestrator` 연동 위치에 실제 스케줄러 연결 주석을 추가합니다.
-   - [ ] 권한 확인/요청 흐름을 설계합니다.
+4. [x] **알림 연결 준비**
+   - [x] `ReminderOrchestrator`에 `AndroidReminderScheduler`를 연결해 AlarmManager/WorkManager와 연동합니다.
+   - [x] 알림 권한 확인/요청 흐름을 Compose에서 안내합니다.
 5. [ ] **품질 보강**
    - [ ] Compose Preview와 UI 테스트를 추가해 회귀를 막습니다.
    - [ ] ViewModel/도메인 단위 테스트로 Day/Week/Month 집계를 검증합니다.
 
 ## 이후 확장 아이디어
-- Room과 WorkManager를 다시 연결해 영속 저장 및 실제 알림 발송을 구현합니다.
+- Room과 실제 저장소를 연결해 인메모리 데이터를 대체하고, WorkManager 기반 알림을 영속화합니다.
 - 다국어 지원과 접근성(콘텐츠 설명, 대비, 폰트 크기 대응)을 점검합니다.
 - 홈 화면 위젯과 다크 모드 대응을 준비합니다.
 

--- a/docs/progress-audit.md
+++ b/docs/progress-audit.md
@@ -1,17 +1,17 @@
 # 진행 상황 점검 보고서
 
 ## README 기준 현재 요약
-- README에는 도메인 모델, 애그리게이터, 알림 오케스트레이션이 구현되었고 저장소/알림 계층은 목(mock) 상태이며 Compose UI 작업이 남아 있다고 적혀 있습니다.【F:README.md†L62-L74】
-- 저장소 코드도 이를 확인해 줍니다. 도메인 엔터티와 알림 로직은 `app/src/main/kotlin/com/example/calendar/data` 및 `.../reminder` 아래에 정리되어 있고, `QuickStartAppContainer`는 여전히 인메모리 저장소와 `NoOpReminderScheduler`에 연결되어 있습니다.【F:app/src/main/kotlin/com/example/calendar/data/Task.kt†L14-L35】【F:app/src/main/kotlin/com/example/calendar/reminder/ReminderOrchestrator.kt†L10-L66】【F:app/src/main/kotlin/com/example/calendar/QuickStartAppContainer.kt†L31-L96】
-- 다만 README의 설명과 달리, 현재 레포에는 `AgendaRoute`/`AgendaScreen`을 포함한 Compose UI 뼈대가 존재하므로 “UI 미구현”이라는 문구는 최신 상태가 아닙니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L82-L353】
+- README는 도메인 계층, 아젠다 UI, 빠른 추가, 그리고 알림 오케스트레이션이 연결되었음을 명시하고 있습니다.【F:README.md†L42-L89】
+- 런타임 구현에서도 `QuickStartAppContainer`가 `AndroidReminderScheduler`를 주입해 AlarmManager/WorkManager와 연동하고, `CalendarApp`이 알림 권한 카드를 노출합니다.【F:app/src/main/kotlin/com/example/calendar/QuickStartAppContainer.kt†L31-L109】【F:app/src/main/kotlin/com/example/calendar/ui/CalendarApp.kt†L15-L167】
+- `AgendaRoute`/`AgendaScreen`은 상세 시트, 퀵 추가 시트, 스낵바 안내까지 포함한 인터랙션을 제공하고 있습니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L82-L324】
 
 ## `docs/next-steps.md` 체크리스트 진행도
 1. **UI 뼈대 구성 (Step 1)** – 완료. `AgendaRoute`가 `AgendaViewModel`과 상태를 연동하고, 탭/기간 상태를 관리하며 `AgendaAggregator`에서 가져온 일/주/월 콘텐츠를 렌더링합니다.【F:docs/next-steps.md†L10-L18】【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L82-L210】【F:app/src/main/kotlin/com/example/calendar/scheduler/AgendaAggregator.kt†L16-L53】
-2. **상호작용 추가 (Step 2)** – 부분 충족. 상세 정보 바텀시트에서 토글·삭제·편집 훅을 제공하고, 작업 행은 접근성 라벨을 포함한 스와이프 완료 제스처를 지원합니다.【F:docs/next-steps.md†L15-L18】【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L287-L758】【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L1187-L1334】
-3. **입력 및 저장 (Step 3)** – **미완료.** 스캐폴드에는 `onQuickAddClick` 슬롯이 노출되어 있지만 `AgendaRoute`에서 실제 핸들러를 전달하지 않고, 퀵 추가 시트를 구현한 코드도 없으며 참조된 `QuickAddType` 열거형이 존재하지 않아 FAB으로 항목을 추가할 수 없습니다.【F:docs/next-steps.md†L19-L21】【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L287-L369】【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L175-L210】【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L356-L369】
-4. **알림 연결 준비 (Step 4)** – 진행 전. 오케스트레이터는 여전히 `NoOpReminderScheduler`에 위임하고 있으며 런타임 권한 확인을 위한 주석이나 흐름도 준비되어 있지 않습니다.【F:docs/next-steps.md†L22-L24】【F:app/src/main/kotlin/com/example/calendar/QuickStartAppContainer.kt†L90-L96】
+2. **상호작용 추가 (Step 2)** – 세부 폴리시와 접근성 QA는 남아 있지만 상세 시트, 스와이프 액션, 스낵바 메시지가 작동합니다.【F:docs/next-steps.md†L15-L18】【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L287-L758】
+3. **입력 및 저장 (Step 3)** – 완료. FAB가 퀵 추가 시트를 열고, 입력 검증/성공 메시지를 처리하며 저장 시 리마인더를 예약합니다.【F:docs/next-steps.md†L19-L21】【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L232-L324】【F:app/src/main/kotlin/com/example/calendar/ui/AgendaViewModel.kt†L57-L152】
+4. **알림 연결 준비 (Step 4)** – 완료. 실제 스케줄러가 주입되었고, Compose에서 알림 권한 요청 카드를 노출합니다.【F:docs/next-steps.md†L22-L24】【F:app/src/main/kotlin/com/example/calendar/QuickStartAppContainer.kt†L90-L109】【F:app/src/main/kotlin/com/example/calendar/ui/CalendarApp.kt†L42-L160】
 5. **품질 보강 (Step 5)** – 부분 진행. ViewModel/도메인 테스트(`AgendaViewModelTest`, `AgendaAggregatorTest`, `ReminderOrchestratorTest`)는 존재하지만 Compose 프리뷰나 UI 테스트는 아직 마련되지 않았습니다.【F:docs/next-steps.md†L25-L27】【F:app/src/test/kotlin/com/example/calendar/ui/AgendaViewModelTest.kt†L33-L153】
 
 ## 추가 관찰
 - 현재 아젠다 화면에는 `SwipeableTaskRow`, `AgendaDetailSheet` 등 중복된 컴포저블이 함께 존재해 머지 충돌 잔재로 보이며, 본격적인 UI 작업에 앞서 정리가 필요합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L807-L1009】【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L1032-L1406】
-- 퀵 추가 로직이 비어 있으므로, 실제 알람/저장소 계층을 통합하거나 UI 프리뷰·테스트를 도입하기 전에 Step 3 완성이 가장 우선입니다.
+- 알림 권한 카드를 한 번 닫으면 다시 보여주지 않으므로, 재노출 조건을 기획과 함께 정의해야 합니다.


### PR DESCRIPTION
## Summary
- wire the app container to AndroidReminderScheduler so reminders schedule through AlarmManager and WorkManager
- surface a Compose notification-permission prompt and agenda slot that requests or deep-links to settings before scheduling alerts
- refresh the README and roadmap docs to mark the reminder hand-off complete and outline the next follow-ups

## Testing
- ./gradlew test *(fails: Gradle wrapper is not present in the repository)*

------
https://chatgpt.com/codex/tasks/task_e_68eeef2867cc832d869baf429b4c86b5