### PR TITLE
Add Room-backed app container

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,11 @@
 - Compose Agenda 화면이 일·주·월 탭, 상세 바텀 시트, 스와이프 제스처, 빠른 추가, 알림 권한 안내까지 포함해 구현되었습니다.
 - `AgendaViewModel`이 애그리게이터·리포지토리와 연결되어 일정/할 일 토글·삭제·빠른 추가 시 리마인더 스케줄링까지 처리합니다.
 - `ReminderOrchestrator`와 `AndroidReminderScheduler`가 AlarmManager·WorkManager·워커/리시버 연동으로 알림 예약 파이프라인을 구성했습니다.
+- Room 기반 `RoomAppContainer`가 `CalendarDatabase`를 빌드해 `RoomTaskRepository`와 `RoomEventRepository`를 주입하므로 앱 재시작 후에도 데이터가 유지됩니다.
 - 단위/계측 테스트로 애그리게이터, 뷰모델, Compose Agenda 화면 핵심 시나리오를 검증합니다.
 - Gradle 래퍼와 GitHub Actions CI 워크플로가 포함되어 일관된 빌드 환경을 제공합니다.
 
 ### 부분 완료
-- Room 데이터베이스/DAO/Repository는 준비돼 있으나 `QuickStartAppContainer`가 인메모리 저장소를 주입해 실제 영속 계층 연결이 미완료입니다.
 - 리마인더 예약은 가능하지만 Task/Event의 `reminders` 정보가 인메모리 샘플과 함께만 유지되어 앱 재시작 시 복원 로직이 부족합니다.
 
 ### 미구현
@@ -50,9 +50,8 @@
 - WorkManager/AlarmManager 연동을 계측 또는 통합 테스트로 검증하는 자동화가 아직 없습니다.
 
 ### 남은 과제
-1. Room 기반 `AppContainer`를 작성해 `CalendarDatabase` 빌드 및 `RoomTaskRepository`/`RoomEventRepository`를 주입하고 인메모리 컨테이너를 교체합니다.
-2. 리마인더 저장/복원 전략을 추가해 `ReminderOrchestrator` 스케줄이 기기 재부팅이나 앱 재시작 후에도 유지되도록 합니다.
-3. 알림 권한 안내·빠른 추가 플로우에 대한 계측/통합 테스트를 보강해 회귀를 방지합니다.
+1. 리마인더 저장/복원 전략을 추가해 `ReminderOrchestrator` 스케줄이 기기 재부팅이나 앱 재시작 후에도 유지되도록 합니다.
+2. 알림 권한 안내·빠른 추가 플로우에 대한 계측/통합 테스트를 보강해 회귀를 방지합니다.
 
 ## 우선순위 로드맵
 | 우선순위 | 작업 | 상태 | 메모 |

--- a/app/src/main/kotlin/com/example/calendar/CalendarApplication.kt
+++ b/app/src/main/kotlin/com/example/calendar/CalendarApplication.kt
@@ -12,7 +12,7 @@ class CalendarApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        container = QuickStartAppContainer(applicationContext)
+        container = RoomAppContainer(applicationContext)
     }
 }
 

--- a/app/src/main/kotlin/com/example/calendar/RoomAppContainer.kt
+++ b/app/src/main/kotlin/com/example/calendar/RoomAppContainer.kt
@@ -1,0 +1,62 @@
+package com.example.calendar
+
+import android.app.AlarmManager
+import android.content.Context
+import androidx.room.Room
+import androidx.work.WorkManager
+import com.example.calendar.data.CalendarDatabase
+import com.example.calendar.data.EventRepository
+import com.example.calendar.data.RoomEventRepository
+import com.example.calendar.data.RoomTaskRepository
+import com.example.calendar.data.TaskRepository
+import com.example.calendar.reminder.AndroidReminderScheduler
+import com.example.calendar.reminder.ReminderOrchestrator
+import com.example.calendar.scheduler.AgendaAggregator
+
+/**
+ * Production container backed by a Room database so tasks and events survive
+ * process death and app restarts.
+ */
+class RoomAppContainer(
+    private val context: Context
+) : AppContainer {
+
+    private val database: CalendarDatabase by lazy {
+        Room.databaseBuilder(
+            context,
+            CalendarDatabase::class.java,
+            CalendarDatabase.DATABASE_NAME
+        )
+            .fallbackToDestructiveMigration()
+            .build()
+    }
+
+    override val taskRepository: TaskRepository by lazy {
+        RoomTaskRepository(database.taskDao())
+    }
+
+    override val eventRepository: EventRepository by lazy {
+        RoomEventRepository(database.calendarEventDao())
+    }
+
+    private val alarmManager: AlarmManager by lazy {
+        context.getSystemService(AlarmManager::class.java)
+            ?: context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+    }
+
+    private val workManager: WorkManager by lazy { WorkManager.getInstance(context) }
+
+    override val reminderOrchestrator: ReminderOrchestrator by lazy {
+        ReminderOrchestrator(
+            AndroidReminderScheduler(
+                context = context,
+                alarmManager = alarmManager,
+                workManager = workManager
+            )
+        )
+    }
+
+    override val agendaAggregator: AgendaAggregator by lazy {
+        AgendaAggregator(taskRepository, eventRepository)
+    }
+}


### PR DESCRIPTION
## Summary
- add a Room-backed AppContainer that builds CalendarDatabase and exposes RoomTaskRepository/RoomEventRepository
- update CalendarApplication to bootstrap the new container instead of the in-memory quick start implementation
- document the Room integration in the project README

## Testing
- ./gradlew testDebugUnitTest *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68ef623abaa8832d9fcea67a6eb52f53