### PR TITLE
Add agenda edit modals and refresh documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - `AgendaAggregator`가 기간별(일/주/월) 일정과 할 일을 통합해 반복 일정 전개, 예외 처리, 겹침 탐지를 수행합니다.【F:app/src/main/kotlin/com/example/calendar/scheduler/AgendaAggregator.kt†L16-L140】
 - Compose 기반 `AgendaRoute`/`AgendaScreen`이 탭 전환, 기간 이동, 상세 바텀 시트, 스와이프 삭제, 완료 상태/반복 항목 필터를 제공해 주요 상호작용을 모두 지원합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L82-L1180】
 - FAB에서 열리는 빠른 추가 시트가 최소 입력으로 새 할 일·일정을 생성하고, 성공/실패 스낵바와 상세 보기 연결까지 처리합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L232-L377】【F:app/src/main/kotlin/com/example/calendar/ui/AgendaViewModel.kt†L57-L152】
+- 상세 시트의 `편집` 버튼이 상위 `CalendarApp`의 전용 편집 시트로 연결되어 기존 일정·할 일을 바로 수정할 수 있습니다.【F:app/src/main/kotlin/com/example/calendar/ui/CalendarApp.kt†L20-L121】【F:app/src/main/kotlin/com/example/calendar/ui/agenda/EditSheets.kt†L1-L170】
 
 ### 2. 리마인더 시스템
 - `RoomAppContainer`가 AlarmManager·WorkManager·SharedPreferences를 묶어 `ReminderOrchestrator`를 구성하고, 앱 전체에서 동일한 스케줄러 인스턴스를 사용합니다.【F:app/src/main/kotlin/com/example/calendar/RoomAppContainer.kt†L17-L75】
@@ -17,7 +18,7 @@
 ### 3. 데이터 계층 및 앱 구성
 - `CalendarApplication`이 `RoomAppContainer`를 초기화해 Room DAO 기반 저장소와 리마인더 오케스트레이터를 주입합니다.【F:app/src/main/kotlin/com/example/calendar/CalendarApplication.kt†L9-L20】【F:app/src/main/kotlin/com/example/calendar/RoomAppContainer.kt†L28-L75】
 - Room 엔티티/DAO가 일정·할 일·리마인더 데이터를 보존하고 스트림으로 제공해 UI가 즉시 갱신됩니다.【F:app/src/main/kotlin/com/example/calendar/data/CalendarEvent.kt†L8-L54】【F:app/src/main/kotlin/com/example/calendar/data/Task.kt†L8-L86】【F:app/src/main/kotlin/com/example/calendar/data/CalendarDatabase.kt†L8-L32】
-- 메인 진입점은 `MainActivity`의 Compose `CalendarApp`으로, 알림 권한 카드와 Agenda 화면을 결합합니다.【F:app/src/main/kotlin/com/example/calendar/MainActivity.kt†L7-L25】【F:app/src/main/kotlin/com/example/calendar/ui/CalendarApp.kt†L18-L88】
+- 메인 진입점은 `MainActivity`의 Compose `CalendarApp`으로, 알림 권한 카드와 Agenda 화면을 결합합니다.【F:app/src/main/kotlin/com/example/calendar/MainActivity.kt†L7-L25】【F:app/src/main/kotlin/com/example/calendar/ui/CalendarApp.kt†L18-L121】
 
 ### 4. 테스트 커버리지
 - 도메인/리마인더 단위 테스트가 반복 일정 전개, 충돌 탐지, 알림 재예약을 검증합니다.【F:app/src/test/kotlin/com/example/calendar/scheduler/AgendaAggregatorTest.kt†L17-L124】【F:app/src/test/kotlin/com/example/calendar/reminder/ReminderReschedulerTest.kt†L13-L119】
@@ -25,11 +26,10 @@
 - Compose 계측 테스트가 빠른 추가 흐름과 알림 권한 카드 UI를 검증합니다.【F:app/src/androidTest/kotlin/com/example/calendar/ui/QuickAddFlowTest.kt†L8-L55】【F:app/src/androidTest/kotlin/com/example/calendar/ui/CalendarAppNotificationTest.kt†L8-L46】
 
 ## 남은 과제
-1. **편집 화면/내비게이션 연결** – 상세 시트의 `편집` 버튼이 `onTaskEdit`/`onEventEdit` 콜백만 호출하며 기본 구현이 없어 실제 편집 화면으로 연결되지 않습니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L1404-L1477】
-2. **리마인더 구성 UI** – 빠른 추가 시트가 제목/시간만 입력받고 리마인더 오프셋·스누즈 설정을 노출하지 않아, 요구사항에 있는 사용자 지정 리마인더 구성이 불가합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L1479-L1662】
-3. **현지화 리소스 확장** – 대부분의 UI 문구가 Compose 내부에 하드코딩되어 있어 문자열 리소스화와 다국어 지원이 필요합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L707-L1165】【F:app/src/main/res/values/strings.xml†L1-L8】
-4. **동기화·백엔드 연동** – `docs/sync-conflict-strategy.md`에 정의된 클라우드 동기화 정책은 설계만 존재하고 구현되지 않았습니다.【F:docs/sync-conflict-strategy.md†L1-L33】
-5. **접근성/시각 구조 정리** – Agenda 화면에 중복된 카드/리스트 컴포저블이 남아 있어 구조 단순화와 스크린 리더 QA가 필요합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L807-L1406】
+1. **리마인더 구성 UI** – 빠른 추가 시트가 제목/시간만 입력받고 리마인더 오프셋·스누즈 설정을 노출하지 않아, 요구사항에 있는 사용자 지정 리마인더 구성이 불가합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L1512-L1754】
+2. **현지화 리소스 확장** – 대부분의 UI 문구가 Compose 내부에 하드코딩되어 있어 문자열 리소스화와 다국어 지원이 필요합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L707-L1165】【F:app/src/main/res/values/strings.xml†L1-L8】
+3. **동기화·백엔드 연동** – `docs/sync-conflict-strategy.md`에 정의된 클라우드 동기화 정책은 설계만 존재하고 구현되지 않았습니다.【F:docs/sync-conflict-strategy.md†L1-L33】
+4. **접근성/시각 구조 정리** – Agenda 화면에 중복된 카드/리스트 컴포저블이 남아 있어 구조 단순화와 스크린 리더 QA가 필요합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L807-L1406】
 
 ## 실행 및 테스트 방법
 1. **의존성 설치**: Android Studio에서 Gradle 동기화를 수행하거나 CLI에서 `./gradlew tasks`로 래퍼 동작을 확인합니다.

--- a/app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaTimeUtils.kt
+++ b/app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaTimeUtils.kt
@@ -1,0 +1,12 @@
+package com.example.calendar.ui.agenda
+
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+internal val QuickAddTimeFormatter: DateTimeFormatter =
+    DateTimeFormatter.ofPattern("H:mm", Locale.KOREAN)
+
+internal fun parseInputTime(value: String): Result<LocalTime> {
+    return runCatching { LocalTime.parse(value.trim(), QuickAddTimeFormatter) }
+}

--- a/app/src/main/kotlin/com/example/calendar/ui/agenda/EditSheets.kt
+++ b/app/src/main/kotlin/com/example/calendar/ui/agenda/EditSheets.kt
@@ -1,0 +1,324 @@
+package com.example.calendar.ui.agenda
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import java.time.LocalDate
+import java.time.LocalDateTime
+import kotlinx.coroutines.launch
+import com.example.calendar.data.CalendarEvent
+import com.example.calendar.data.Task
+
+@Composable
+fun TaskEditSheet(
+    task: Task,
+    onSaveTask: suspend (title: String, notes: String?, dueAt: LocalDateTime?) -> Result<Task>,
+    onSaved: (Task) -> Unit,
+    onClose: () -> Unit
+) {
+    var title by rememberSaveable(task.id.toString()) { mutableStateOf(task.title) }
+    var notes by rememberSaveable(task.id.toString()) { mutableStateOf(task.description.orEmpty()) }
+    var dueDateText by rememberSaveable(task.id.toString()) {
+        mutableStateOf(task.dueAt?.toLocalDate()?.toString() ?: "")
+    }
+    var dueTimeText by rememberSaveable(task.id.toString()) {
+        mutableStateOf(task.dueAt?.toLocalTime()?.format(QuickAddTimeFormatter) ?: "")
+    }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+    var isSaving by remember { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = "할 일 편집",
+            style = MaterialTheme.typography.titleLarge
+        )
+        OutlinedTextField(
+            value = title,
+            onValueChange = { title = it },
+            label = { Text("제목") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+        OutlinedTextField(
+            value = notes,
+            onValueChange = { notes = it },
+            label = { Text("메모 (선택)") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        OutlinedTextField(
+            value = dueDateText,
+            onValueChange = { dueDateText = it },
+            label = { Text("마감 날짜 (YYYY-MM-DD)") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+            supportingText = {
+                Text(
+                    text = "비워 두면 날짜 없이 저장됩니다.",
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+        )
+        OutlinedTextField(
+            value = dueTimeText,
+            onValueChange = { dueTimeText = it },
+            label = { Text("마감 시간 (HH:mm)") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+            supportingText = {
+                Text(
+                    text = "날짜 또는 시간을 비워 두면 마감 시간이 제거됩니다.",
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+        )
+
+        errorMessage?.let { message ->
+            Text(
+                text = message,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.End)
+        ) {
+            TextButton(onClick = { if (!isSaving) onClose() }) {
+                Text("취소")
+            }
+            Button(
+                onClick = {
+                    if (isSaving) return@Button
+                    val normalizedTitle = title.trim()
+                    if (normalizedTitle.isEmpty()) {
+                        errorMessage = "제목을 입력해 주세요."
+                        return@Button
+                    }
+                    val normalizedNotes = notes.trim().takeIf { it.isNotEmpty() }
+                    val dateText = dueDateText.trim()
+                    val timeText = dueTimeText.trim()
+
+                    val dueAt = if (dateText.isEmpty() && timeText.isEmpty()) {
+                        null
+                    } else {
+                        if (dateText.isEmpty()) {
+                            errorMessage = "마감 날짜를 YYYY-MM-DD 형식으로 입력해 주세요."
+                            return@Button
+                        }
+                        val dateResult = runCatching { LocalDate.parse(dateText) }
+                        if (dateResult.isFailure) {
+                            errorMessage = "마감 날짜는 YYYY-MM-DD 형식이어야 해요."
+                            return@Button
+                        }
+                        if (timeText.isEmpty()) {
+                            errorMessage = "마감 시간을 HH:mm 형식으로 입력해 주세요."
+                            return@Button
+                        }
+                        val timeResult = parseInputTime(timeText)
+                        if (timeResult.isFailure) {
+                            errorMessage = "마감 시간은 HH:mm 형식이어야 해요."
+                            return@Button
+                        }
+                        LocalDateTime.of(dateResult.getOrThrow(), timeResult.getOrThrow())
+                    }
+
+                    coroutineScope.launch {
+                        isSaving = true
+                        errorMessage = null
+                        val result = onSaveTask(normalizedTitle, normalizedNotes, dueAt)
+                        if (result.isSuccess) {
+                            onSaved(result.getOrThrow())
+                        } else {
+                            errorMessage = result.exceptionOrNull()?.message ?: "저장에 실패했습니다."
+                        }
+                        isSaving = false
+                    }
+                },
+                enabled = !isSaving
+            ) {
+                Text(if (isSaving) "저장 중..." else "저장")
+            }
+        }
+    }
+}
+
+@Composable
+fun EventEditSheet(
+    event: CalendarEvent,
+    onSaveEvent: suspend (
+        title: String,
+        description: String?,
+        location: String?,
+        start: LocalDateTime,
+        end: LocalDateTime
+    ) -> Result<CalendarEvent>,
+    onSaved: (CalendarEvent) -> Unit,
+    onClose: () -> Unit
+) {
+    var title by rememberSaveable(event.id.toString()) { mutableStateOf(event.title) }
+    var location by rememberSaveable(event.id.toString()) { mutableStateOf(event.location.orEmpty()) }
+    var notes by rememberSaveable(event.id.toString()) { mutableStateOf(event.description.orEmpty()) }
+    var dateText by rememberSaveable(event.id.toString()) { mutableStateOf(event.start.toLocalDate().toString()) }
+    var startTimeText by rememberSaveable(event.id.toString()) {
+        mutableStateOf(event.start.toLocalTime().format(QuickAddTimeFormatter))
+    }
+    var endTimeText by rememberSaveable(event.id.toString()) {
+        mutableStateOf(event.end.toLocalTime().format(QuickAddTimeFormatter))
+    }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+    var isSaving by remember { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
+
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    ) {
+        Text(
+            text = "일정 편집",
+            style = MaterialTheme.typography.titleLarge
+        )
+        OutlinedTextField(
+            value = title,
+            onValueChange = { title = it },
+            label = { Text("제목") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+        OutlinedTextField(
+            value = location,
+            onValueChange = { location = it },
+            label = { Text("위치 (선택)") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        OutlinedTextField(
+            value = notes,
+            onValueChange = { notes = it },
+            label = { Text("메모 (선택)") },
+            modifier = Modifier.fillMaxWidth()
+        )
+        OutlinedTextField(
+            value = dateText,
+            onValueChange = { dateText = it },
+            label = { Text("날짜 (YYYY-MM-DD)") },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth()
+        )
+        Row(
+            horizontalArrangement = Arrangement.spacedBy(12.dp)
+        ) {
+            OutlinedTextField(
+                value = startTimeText,
+                onValueChange = { startTimeText = it },
+                label = { Text("시작 시간 (HH:mm)") },
+                singleLine = true,
+                modifier = Modifier.weight(1f)
+            )
+            OutlinedTextField(
+                value = endTimeText,
+                onValueChange = { endTimeText = it },
+                label = { Text("종료 시간 (HH:mm)") },
+                singleLine = true,
+                modifier = Modifier.weight(1f)
+            )
+        }
+
+        errorMessage?.let { message ->
+            Text(
+                text = message,
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(12.dp, Alignment.End)
+        ) {
+            TextButton(onClick = { if (!isSaving) onClose() }) {
+                Text("취소")
+            }
+            Button(
+                onClick = {
+                    if (isSaving) return@Button
+                    val normalizedTitle = title.trim()
+                    if (normalizedTitle.isEmpty()) {
+                        errorMessage = "제목을 입력해 주세요."
+                        return@Button
+                    }
+                    val normalizedLocation = location.trim().takeIf { it.isNotEmpty() }
+                    val normalizedNotes = notes.trim().takeIf { it.isNotEmpty() }
+                    val parsedDate = runCatching { LocalDate.parse(dateText.trim()) }
+                    if (parsedDate.isFailure) {
+                        errorMessage = "날짜는 YYYY-MM-DD 형식이어야 해요."
+                        return@Button
+                    }
+                    val startResult = parseInputTime(startTimeText.trim())
+                    if (startResult.isFailure) {
+                        errorMessage = "시작 시간은 HH:mm 형식이어야 해요."
+                        return@Button
+                    }
+                    val endResult = parseInputTime(endTimeText.trim())
+                    if (endResult.isFailure) {
+                        errorMessage = "종료 시간은 HH:mm 형식이어야 해요."
+                        return@Button
+                    }
+
+                    val date = parsedDate.getOrThrow()
+                    val startDateTime = LocalDateTime.of(date, startResult.getOrThrow())
+                    val endDateTime = LocalDateTime.of(date, endResult.getOrThrow())
+                    if (endDateTime.isBefore(startDateTime)) {
+                        errorMessage = "종료 시간은 시작 시간 이후여야 합니다."
+                        return@Button
+                    }
+
+                    coroutineScope.launch {
+                        isSaving = true
+                        errorMessage = null
+                        val result = onSaveEvent(
+                            normalizedTitle,
+                            normalizedNotes,
+                            normalizedLocation,
+                            startDateTime,
+                            endDateTime
+                        )
+                        if (result.isSuccess) {
+                            onSaved(result.getOrThrow())
+                        } else {
+                            errorMessage = result.exceptionOrNull()?.message ?: "저장에 실패했습니다."
+                        }
+                        isSaving = false
+                    }
+                },
+                enabled = !isSaving
+            ) {
+                Text(if (isSaving) "저장 중..." else "저장")
+            }
+        }
+    }
+}

--- a/docs/remaining-work.md
+++ b/docs/remaining-work.md
@@ -4,31 +4,32 @@
 
 | 영역 | 미완료 항목 | 영향 | 다음 조치 |
 | --- | --- | --- | --- |
-| 편집 플로우 | 상세 시트의 `편집` 버튼이 내비게이션과 연결되지 않음 | 사용자가 기존 일정/할 일을 수정할 방법이 없음 | 전용 편집 화면/다이얼로그를 만들고 `AgendaRoute` 콜백을 실제 내비게이션과 연결 |
 | 리마인더 구성 | 빠른 추가 시 리마인더 오프셋·스누즈를 설정할 수 없음 | 요구사항상의 사용자 정의 리마인더 경험 부족 | 빠른 추가 및 정식 편집 플로우에 리마인더 입력 필드를 추가하고 `ReminderOrchestrator`에 전달 |
 | 현지화 | Compose 내부에 한국어 문자열이 하드코딩되어 있음 | 다국어/접근성 대응 불가 | 문자열을 `strings.xml`로 추출하고 번역 키를 준비 |
 | UI 구조 | Agenda 화면에 유사한 카드/리스트 컴포저블이 중복 선언됨 | 유지보수성·스크린 리더 탐색성 저하 | 공통 컴포넌트를 정리하고 의미 있는 heading/role 속성을 재검토 |
 | 동기화 | `docs/sync-conflict-strategy.md`에 정의된 클라우드 동기화 정책 미구현 | 멀티 디바이스/오프라인 사용 시 데이터 손실 우려 | 서버/동기화 계층을 도입하고 충돌 해결 정책을 실제 코드로 이전 |
 
+## 완료된 항목
+
+### 편집 플로우 보완 (완료)
+- 상세 시트에서 `편집`을 누르면 상위 `CalendarApp`이 전용 편집 모달 시트를 열어 기존 일정·할 일을 수정할 수 있습니다.【F:app/src/main/kotlin/com/example/calendar/ui/CalendarApp.kt†L20-L121】【F:app/src/main/kotlin/com/example/calendar/ui/agenda/EditSheets.kt†L1-L170】
+- `AgendaRoute`는 편집 버튼을 누를 때 상세 시트를 닫고 콜백을 호출해 상위 내비게이션과 자연스럽게 연동합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L264-L310】
+
 ## 세부 항목
 
-### 1. 편집 플로우 보완
-- `TaskDetailSheet`와 `EventDetailSheet`의 `편집` 버튼은 `onTaskEdit`/`onEventEdit` 콜백만 호출하며, 기본 구현은 비어 있습니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L1404-L1477】
-- 실제 편집 화면 또는 다이얼로그를 정의하고, `AgendaRoute` 상위에서 내비게이션을 제공해야 합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L103-L129】
-
-### 2. 리마인더 구성 UI 추가
-- 빠른 추가 시트는 제목·메모·시간만 입력받아 리마인더 설정을 변경할 수 없습니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L1479-L1662】
+### 1. 리마인더 구성 UI 추가
+- 빠른 추가 시트는 제목·메모·시간만 입력받아 리마인더 설정을 변경할 수 없습니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L1512-L1754】
 - `AgendaViewModel`도 기본 리마인더 이외에 오프셋 목록을 처리하지 않습니다.【F:app/src/main/kotlin/com/example/calendar/ui/AgendaViewModel.kt†L57-L152】
 - 사용자가 선택한 오프셋을 `ReminderPayload`로 변환해 `ReminderOrchestrator`에 전달하는 로직이 필요합니다.【F:app/src/main/kotlin/com/example/calendar/reminder/ReminderOrchestrator.kt†L16-L91】
 
-### 3. 현지화 리소스 정비
+### 2. 현지화 리소스 정비
 - 대다수 Compose 텍스트가 하드코딩되어 있고, `strings.xml`에는 앱 이름과 알림 관련 문자열만 존재합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L707-L1165】【F:app/src/main/res/values/strings.xml†L1-L8】
 - 문자열을 리소스로 추출하고, 접근성 설명(`contentDescription`, `stateDescription`)도 Locale 대응이 가능하도록 개선해야 합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L914-L1100】
 
-### 4. Agenda UI 구조 개선
+### 3. Agenda UI 구조 개선
 - `AgendaScreen`에는 리스트/요약 컴포저블이 유사한 형태로 중복 선언되어 있어 유지보수가 어렵습니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L807-L1406】
 - 기존 Compose UI 테스트는 기본 렌더링만 검증하므로, 접근성 포커스·스크린 리더 플로우를 확인하는 시나리오가 추가로 필요합니다.【F:app/src/androidTest/kotlin/com/example/calendar/ui/agenda/AgendaScreenTest.kt†L19-L70】
 
-### 5. 클라우드 동기화 구현
+### 4. 클라우드 동기화 구현
 - 클라우드 동기화 및 충돌 해결 전략은 문서로만 존재하며 실제 코드에서는 동작하지 않습니다.【F:docs/sync-conflict-strategy.md†L1-L33】
 - Room과 원격 소스를 연결하는 동기화 서비스, 충돌 히스토리 저장, 사용자 알림 흐름을 구현해야 합니다.


### PR DESCRIPTION
## Summary
- route agenda edit actions through `CalendarApp` so task/event sheets open in top-level modal editors
- extract reusable edit sheet composables and shared time utilities for the agenda feature
- update the remaining work document and README after completing the edit flow task

## Testing
- ./gradlew test *(fails: Android SDK not configured in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f1bbe75ee8832da837b63bc92f2ac1