### PR TITLE
Add reminder configuration to quick add sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - `AgendaAggregator`가 기간별(일/주/월) 일정과 할 일을 통합해 반복 일정 전개, 예외 처리, 겹침 탐지를 수행합니다.【F:app/src/main/kotlin/com/example/calendar/scheduler/AgendaAggregator.kt†L16-L140】
 - Compose 기반 `AgendaRoute`/`AgendaScreen`이 탭 전환, 기간 이동, 상세 바텀 시트, 스와이프 삭제, 완료 상태/반복 항목 필터를 제공해 주요 상호작용을 모두 지원합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L82-L1180】
 - FAB에서 열리는 빠른 추가 시트가 최소 입력으로 새 할 일·일정을 생성하고, 성공/실패 스낵바와 상세 보기 연결까지 처리합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L232-L377】【F:app/src/main/kotlin/com/example/calendar/ui/AgendaViewModel.kt†L57-L152】
+- 빠른 추가 시트에서 리마인더 알림 시점과 스누즈 허용 여부를 직접 설정해 저장 즉시 오케스트레이션에 반영합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L1558-L1717】【F:app/src/main/kotlin/com/example/calendar/ui/AgendaViewModel.kt†L163-L211】
 - 상세 시트의 `편집` 버튼이 상위 `CalendarApp`의 전용 편집 시트로 연결되어 기존 일정·할 일을 바로 수정할 수 있습니다.【F:app/src/main/kotlin/com/example/calendar/ui/CalendarApp.kt†L20-L121】【F:app/src/main/kotlin/com/example/calendar/ui/agenda/EditSheets.kt†L1-L170】
 
 ### 2. 리마인더 시스템
@@ -26,10 +27,9 @@
 - Compose 계측 테스트가 빠른 추가 흐름과 알림 권한 카드 UI를 검증합니다.【F:app/src/androidTest/kotlin/com/example/calendar/ui/QuickAddFlowTest.kt†L8-L55】【F:app/src/androidTest/kotlin/com/example/calendar/ui/CalendarAppNotificationTest.kt†L8-L46】
 
 ## 남은 과제
-1. **리마인더 구성 UI** – 빠른 추가 시트가 제목/시간만 입력받고 리마인더 오프셋·스누즈 설정을 노출하지 않아, 요구사항에 있는 사용자 지정 리마인더 구성이 불가합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L1512-L1754】
-2. **현지화 리소스 확장** – 대부분의 UI 문구가 Compose 내부에 하드코딩되어 있어 문자열 리소스화와 다국어 지원이 필요합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L707-L1165】【F:app/src/main/res/values/strings.xml†L1-L8】
-3. **동기화·백엔드 연동** – `docs/sync-conflict-strategy.md`에 정의된 클라우드 동기화 정책은 설계만 존재하고 구현되지 않았습니다.【F:docs/sync-conflict-strategy.md†L1-L33】
-4. **접근성/시각 구조 정리** – Agenda 화면에 중복된 카드/리스트 컴포저블이 남아 있어 구조 단순화와 스크린 리더 QA가 필요합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L807-L1406】
+1. **현지화 리소스 확장** – 대부분의 UI 문구가 Compose 내부에 하드코딩되어 있어 문자열 리소스화와 다국어 지원이 필요합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L707-L1165】【F:app/src/main/res/values/strings.xml†L1-L8】
+2. **동기화·백엔드 연동** – `docs/sync-conflict-strategy.md`에 정의된 클라우드 동기화 정책은 설계만 존재하고 구현되지 않았습니다.【F:docs/sync-conflict-strategy.md†L1-L33】
+3. **접근성/시각 구조 정리** – Agenda 화면에 중복된 카드/리스트 컴포저블이 남아 있어 구조 단순화와 스크린 리더 QA가 필요합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L807-L1406】
 
 ## 실행 및 테스트 방법
 1. **의존성 설치**: Android Studio에서 Gradle 동기화를 수행하거나 CLI에서 `./gradlew tasks`로 래퍼 동작을 확인합니다.

--- a/docs/remaining-work.md
+++ b/docs/remaining-work.md
@@ -4,12 +4,15 @@
 
 | 영역 | 미완료 항목 | 영향 | 다음 조치 |
 | --- | --- | --- | --- |
-| 리마인더 구성 | 빠른 추가 시 리마인더 오프셋·스누즈를 설정할 수 없음 | 요구사항상의 사용자 정의 리마인더 경험 부족 | 빠른 추가 및 정식 편집 플로우에 리마인더 입력 필드를 추가하고 `ReminderOrchestrator`에 전달 |
 | 현지화 | Compose 내부에 한국어 문자열이 하드코딩되어 있음 | 다국어/접근성 대응 불가 | 문자열을 `strings.xml`로 추출하고 번역 키를 준비 |
 | UI 구조 | Agenda 화면에 유사한 카드/리스트 컴포저블이 중복 선언됨 | 유지보수성·스크린 리더 탐색성 저하 | 공통 컴포넌트를 정리하고 의미 있는 heading/role 속성을 재검토 |
 | 동기화 | `docs/sync-conflict-strategy.md`에 정의된 클라우드 동기화 정책 미구현 | 멀티 디바이스/오프라인 사용 시 데이터 손실 우려 | 서버/동기화 계층을 도입하고 충돌 해결 정책을 실제 코드로 이전 |
 
 ## 완료된 항목
+
+### 리마인더 구성 UI 추가 (완료)
+- 빠른 추가 시트에서 리마인더 스위치와 분 단위 입력, 스누즈 토글을 제공해 사용자 지정 알림 구성을 받을 수 있습니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L1558-L1717】
+- 수집한 설정을 `AgendaViewModel`이 검증 후 `Reminder` 목록으로 저장·스케줄링합니다.【F:app/src/main/kotlin/com/example/calendar/ui/AgendaViewModel.kt†L163-L211】
 
 ### 편집 플로우 보완 (완료)
 - 상세 시트에서 `편집`을 누르면 상위 `CalendarApp`이 전용 편집 모달 시트를 열어 기존 일정·할 일을 수정할 수 있습니다.【F:app/src/main/kotlin/com/example/calendar/ui/CalendarApp.kt†L20-L121】【F:app/src/main/kotlin/com/example/calendar/ui/agenda/EditSheets.kt†L1-L170】
@@ -17,19 +20,14 @@
 
 ## 세부 항목
 
-### 1. 리마인더 구성 UI 추가
-- 빠른 추가 시트는 제목·메모·시간만 입력받아 리마인더 설정을 변경할 수 없습니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L1512-L1754】
-- `AgendaViewModel`도 기본 리마인더 이외에 오프셋 목록을 처리하지 않습니다.【F:app/src/main/kotlin/com/example/calendar/ui/AgendaViewModel.kt†L57-L152】
-- 사용자가 선택한 오프셋을 `ReminderPayload`로 변환해 `ReminderOrchestrator`에 전달하는 로직이 필요합니다.【F:app/src/main/kotlin/com/example/calendar/reminder/ReminderOrchestrator.kt†L16-L91】
-
-### 2. 현지화 리소스 정비
+### 1. 현지화 리소스 정비
 - 대다수 Compose 텍스트가 하드코딩되어 있고, `strings.xml`에는 앱 이름과 알림 관련 문자열만 존재합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L707-L1165】【F:app/src/main/res/values/strings.xml†L1-L8】
 - 문자열을 리소스로 추출하고, 접근성 설명(`contentDescription`, `stateDescription`)도 Locale 대응이 가능하도록 개선해야 합니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L914-L1100】
 
-### 3. Agenda UI 구조 개선
+### 2. Agenda UI 구조 개선
 - `AgendaScreen`에는 리스트/요약 컴포저블이 유사한 형태로 중복 선언되어 있어 유지보수가 어렵습니다.【F:app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt†L807-L1406】
 - 기존 Compose UI 테스트는 기본 렌더링만 검증하므로, 접근성 포커스·스크린 리더 플로우를 확인하는 시나리오가 추가로 필요합니다.【F:app/src/androidTest/kotlin/com/example/calendar/ui/agenda/AgendaScreenTest.kt†L19-L70】
 
-### 4. 클라우드 동기화 구현
+### 3. 클라우드 동기화 구현
 - 클라우드 동기화 및 충돌 해결 전략은 문서로만 존재하며 실제 코드에서는 동작하지 않습니다.【F:docs/sync-conflict-strategy.md†L1-L33】
 - Room과 원격 소스를 연결하는 동기화 서비스, 충돌 히스토리 저장, 사용자 알림 흐름을 구현해야 합니다.


### PR DESCRIPTION
## Summary
- add reminder toggles for quick add tasks and events so users can configure reminder timing and snooze
- persist the configured reminders through AgendaViewModel quick add flows
- update README and remaining-work documentation to reflect the completed reminder UI work

## Testing
- ./gradlew test *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f1c4e7516c832da05bfd7f22380207