### PR TITLE
Add time skew monitoring for agenda alerts

### DIFF
--- a/app/src/main/kotlin/com/example/calendar/CalendarApplication.kt
+++ b/app/src/main/kotlin/com/example/calendar/CalendarApplication.kt
@@ -5,6 +5,7 @@ import com.example.calendar.data.EventRepository
 import com.example.calendar.data.TaskRepository
 import com.example.calendar.reminder.ReminderOrchestrator
 import com.example.calendar.scheduler.AgendaAggregator
+import com.example.calendar.util.TimeSkewMonitor
 
 class CalendarApplication : Application() {
     lateinit var container: AppContainer
@@ -21,4 +22,5 @@ interface AppContainer {
     val eventRepository: EventRepository
     val reminderOrchestrator: ReminderOrchestrator
     val agendaAggregator: AgendaAggregator
+    val timeSkewMonitor: TimeSkewMonitor
 }

--- a/app/src/main/kotlin/com/example/calendar/MainActivity.kt
+++ b/app/src/main/kotlin/com/example/calendar/MainActivity.kt
@@ -15,7 +15,8 @@ class MainActivity : ComponentActivity() {
             aggregator = app.container.agendaAggregator,
             reminderOrchestrator = app.container.reminderOrchestrator,
             taskRepository = app.container.taskRepository,
-            eventRepository = app.container.eventRepository
+            eventRepository = app.container.eventRepository,
+            timeSkewMonitor = app.container.timeSkewMonitor
         )
     }
 

--- a/app/src/main/kotlin/com/example/calendar/QuickStartAppContainer.kt
+++ b/app/src/main/kotlin/com/example/calendar/QuickStartAppContainer.kt
@@ -16,11 +16,15 @@ import android.content.Context.MODE_PRIVATE
 import com.example.calendar.reminder.ReminderOrchestrator
 import com.example.calendar.reminder.SharedPreferencesReminderStore
 import com.example.calendar.scheduler.AgendaAggregator
+import com.example.calendar.util.TimeSkewMonitor
+import java.time.Clock
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.temporal.TemporalAdjusters
+import java.time.Duration
+import java.time.Instant
 
 /**
  * Minimal container that wires the agenda UI to in-memory data so the app shows
@@ -30,6 +34,13 @@ import java.time.temporal.TemporalAdjusters
 class QuickStartAppContainer(
     private val context: Context
 ) : AppContainer {
+
+    companion object {
+        private const val TIME_REFERENCE_PREF = "calendar_time_reference"
+        private const val KEY_LAST_SYNC_EPOCH = "last_sync_epoch"
+    }
+
+    private val referenceClock: Clock = Clock.systemUTC()
 
     private val today: LocalDate = LocalDate.now()
     private val weekStart: LocalDate = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
@@ -107,6 +118,10 @@ class QuickStartAppContainer(
         )
     }
 
+    private val timeReferencePreferences by lazy {
+        context.getSharedPreferences(TIME_REFERENCE_PREF, MODE_PRIVATE)
+    }
+
     override val reminderOrchestrator: ReminderOrchestrator by lazy {
         ReminderOrchestrator(
             AndroidReminderScheduler(
@@ -120,6 +135,22 @@ class QuickStartAppContainer(
 
     override val agendaAggregator: AgendaAggregator by lazy {
         AgendaAggregator(taskRepository, eventRepository)
+    }
+
+    override val timeSkewMonitor: TimeSkewMonitor by lazy {
+        TimeSkewMonitor(
+            referenceTimeProvider = {
+                val stored = timeReferencePreferences.getLong(KEY_LAST_SYNC_EPOCH, 0L)
+                if (stored == 0L) null else Instant.ofEpochMilli(stored)
+            },
+            tolerance = Duration.ofMinutes(3),
+            clock = referenceClock,
+            referenceRecorder = { instant ->
+                timeReferencePreferences.edit()
+                    .putLong(KEY_LAST_SYNC_EPOCH, instant.toEpochMilli())
+                    .apply()
+            }
+        )
     }
 }
 

--- a/app/src/main/kotlin/com/example/calendar/RoomAppContainer.kt
+++ b/app/src/main/kotlin/com/example/calendar/RoomAppContainer.kt
@@ -16,9 +16,13 @@ import com.example.calendar.reminder.ReminderStore
 import com.example.calendar.reminder.ReminderStoreSynchronizer
 import com.example.calendar.reminder.SharedPreferencesReminderStore
 import com.example.calendar.scheduler.AgendaAggregator
+import com.example.calendar.util.TimeSkewMonitor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
 
 /**
  * Production container backed by a Room database so tasks and events survive
@@ -28,7 +32,14 @@ class RoomAppContainer(
     private val context: Context
 ) : AppContainer {
 
+    companion object {
+        private const val TIME_REFERENCE_PREF = "calendar_time_reference"
+        private const val KEY_LAST_SYNC_EPOCH = "last_sync_epoch"
+    }
+
     private val reminderScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private val referenceClock: Clock = Clock.systemUTC()
 
     private val database: CalendarDatabase by lazy {
         Room.databaseBuilder(
@@ -44,6 +55,10 @@ class RoomAppContainer(
         SharedPreferencesReminderStore(
             context.getSharedPreferences(REMINDER_STORE_NAME, Context.MODE_PRIVATE)
         )
+    }
+
+    private val timeReferencePreferences by lazy {
+        context.getSharedPreferences(TIME_REFERENCE_PREF, Context.MODE_PRIVATE)
     }
 
     override val taskRepository: TaskRepository by lazy {
@@ -84,5 +99,21 @@ class RoomAppContainer(
 
     override val agendaAggregator: AgendaAggregator by lazy {
         AgendaAggregator(taskRepository, eventRepository)
+    }
+
+    override val timeSkewMonitor: TimeSkewMonitor by lazy {
+        TimeSkewMonitor(
+            referenceTimeProvider = {
+                val stored = timeReferencePreferences.getLong(KEY_LAST_SYNC_EPOCH, 0L)
+                if (stored == 0L) null else Instant.ofEpochMilli(stored)
+            },
+            tolerance = Duration.ofMinutes(3),
+            clock = referenceClock,
+            referenceRecorder = { instant ->
+                timeReferencePreferences.edit()
+                    .putLong(KEY_LAST_SYNC_EPOCH, instant.toEpochMilli())
+                    .apply()
+            }
+        )
     }
 }

--- a/app/src/main/kotlin/com/example/calendar/ui/AgendaViewModel.kt
+++ b/app/src/main/kotlin/com/example/calendar/ui/AgendaViewModel.kt
@@ -11,11 +11,15 @@ import com.example.calendar.data.TaskRepository
 import com.example.calendar.reminder.ReminderOrchestrator
 import com.example.calendar.scheduler.AgendaAggregator
 import com.example.calendar.scheduler.AgendaSnapshot
+import com.example.calendar.util.TimeSkewDirection
+import com.example.calendar.util.TimeSkewMonitor
+import com.example.calendar.util.TimeSkewResult
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.temporal.TemporalAdjusters
+import java.time.Duration
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -32,7 +36,8 @@ class AgendaViewModel(
     private val aggregator: AgendaAggregator,
     private val reminderOrchestrator: ReminderOrchestrator,
     private val taskRepository: TaskRepository,
-    private val eventRepository: EventRepository
+    private val eventRepository: EventRepository,
+    private val timeSkewMonitor: TimeSkewMonitor
 ) : ViewModel() {
 
     private val _period = MutableStateFlow<AgendaPeriod>(AgendaPeriod.Day(java.time.LocalDate.now()))
@@ -271,6 +276,7 @@ class AgendaViewModel(
             .flatMapLatest { period ->
                 aggregator.observeAgenda(period)
                     .onStart {
+                        maybeNotifyTimeSkew()
                         _state.value = _state.value.copy(
                             isLoading = true,
                             error = null
@@ -291,6 +297,24 @@ class AgendaViewModel(
                 )
             }
             .launchIn(viewModelScope)
+    }
+
+    private suspend fun maybeNotifyTimeSkew() {
+        val result = runCatching { timeSkewMonitor.evaluate() }.getOrNull() ?: return
+        if (result is TimeSkewResult.SkewExceeded) {
+            _state.update { current ->
+                if (current.userMessage is AgendaUserMessage.TimeSkewWarning) {
+                    current
+                } else {
+                    current.copy(
+                        userMessage = AgendaUserMessage.TimeSkewWarning(
+                            difference = result.difference,
+                            direction = result.direction
+                        )
+                    )
+                }
+            }
+        }
     }
 }
 
@@ -374,4 +398,5 @@ enum class QuickAddType {
 sealed class AgendaUserMessage {
     data class QuickAddSuccess(val type: QuickAddType) : AgendaUserMessage()
     data class QuickAddFailure(val reason: String) : AgendaUserMessage()
+    data class TimeSkewWarning(val difference: Duration, val direction: TimeSkewDirection) : AgendaUserMessage()
 }

--- a/app/src/main/kotlin/com/example/calendar/ui/AgendaViewModelFactory.kt
+++ b/app/src/main/kotlin/com/example/calendar/ui/AgendaViewModelFactory.kt
@@ -6,12 +6,14 @@ import com.example.calendar.data.EventRepository
 import com.example.calendar.data.TaskRepository
 import com.example.calendar.reminder.ReminderOrchestrator
 import com.example.calendar.scheduler.AgendaAggregator
+import com.example.calendar.util.TimeSkewMonitor
 
 class AgendaViewModelFactory(
     private val aggregator: AgendaAggregator,
     private val reminderOrchestrator: ReminderOrchestrator,
     private val taskRepository: TaskRepository,
-    private val eventRepository: EventRepository
+    private val eventRepository: EventRepository,
+    private val timeSkewMonitor: TimeSkewMonitor
 ) : ViewModelProvider.Factory {
     @Suppress("UNCHECKED_CAST")
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
@@ -20,7 +22,8 @@ class AgendaViewModelFactory(
                 aggregator = aggregator,
                 reminderOrchestrator = reminderOrchestrator,
                 taskRepository = taskRepository,
-                eventRepository = eventRepository
+                eventRepository = eventRepository,
+                timeSkewMonitor = timeSkewMonitor
             ) as T
         }
         throw IllegalArgumentException("알 수 없는 ViewModel 클래스입니다: ${'$'}{modelClass.name}")

--- a/app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt
+++ b/app/src/main/kotlin/com/example/calendar/ui/agenda/AgendaScreen.kt
@@ -76,11 +76,14 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.res.pluralStringResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.tooling.preview.Preview
+import com.example.calendar.R
 import com.example.calendar.data.AgendaPeriod
 import com.example.calendar.data.CalendarEvent
 import com.example.calendar.data.Recurrence
@@ -96,7 +99,9 @@ import com.example.calendar.ui.AgendaViewModel
 import com.example.calendar.ui.CompletedTaskFilter
 import com.example.calendar.ui.QuickAddType
 import com.example.calendar.ui.theme.CalendarTheme
+import com.example.calendar.util.TimeSkewDirection
 import java.time.DayOfWeek
+import java.time.Duration
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -384,11 +389,12 @@ fun AgendaScreen(
     modifier: Modifier = Modifier
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
+    val snackbarMessage = uiState.userMessage?.let { it.toSnackbarMessage() }
 
-    LaunchedEffect(uiState.userMessage) {
-        uiState.userMessage?.let { message ->
+    LaunchedEffect(snackbarMessage) {
+        snackbarMessage?.let { text ->
             snackbarHostState.showSnackbar(
-                message = message.toSnackbarMessage(),
+                message = text,
                 withDismissAction = true,
                 duration = SnackbarDuration.Short
             )
@@ -2067,12 +2073,47 @@ private fun formatRecurrence(recurrence: Recurrence): String {
     }
 }
 
+@Composable
 private fun AgendaUserMessage.toSnackbarMessage(): String = when (this) {
     is AgendaUserMessage.QuickAddSuccess -> when (type) {
         QuickAddType.Task -> AgendaText.QuickAddResult.taskSuccess
         QuickAddType.Event -> AgendaText.QuickAddResult.eventSuccess
     }
     is AgendaUserMessage.QuickAddFailure -> reason
+    is AgendaUserMessage.TimeSkewWarning -> {
+        val formatted = formatTimeSkewDifference(difference)
+        when (direction) {
+            TimeSkewDirection.DeviceAhead -> stringResource(
+                R.string.time_skew_warning_ahead,
+                formatted
+            )
+            TimeSkewDirection.DeviceBehind -> stringResource(
+                R.string.time_skew_warning_behind,
+                formatted
+            )
+        }
+    }
+}
+
+@Composable
+private fun formatTimeSkewDifference(duration: Duration): String {
+    val parts = mutableListOf<String>()
+    val hours = duration.toHours()
+    if (hours > 0) {
+        val hoursInt = hours.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+        parts += pluralStringResource(R.plurals.time_skew_hours, hoursInt, hoursInt)
+    }
+    val minutes = duration.toMinutes() % 60
+    if (minutes > 0) {
+        val minutesInt = minutes.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+        parts += pluralStringResource(R.plurals.time_skew_minutes, minutesInt, minutesInt)
+    }
+    if (parts.isEmpty()) {
+        val seconds = duration.seconds.coerceAtLeast(1)
+        val secondsInt = seconds.coerceAtMost(Int.MAX_VALUE.toLong()).toInt()
+        parts += pluralStringResource(R.plurals.time_skew_seconds, secondsInt, secondsInt)
+    }
+    return parts.joinToString(separator = " ")
 }
 
 private fun AgendaTab.displayLabel(): String = when (this) {

--- a/app/src/main/kotlin/com/example/calendar/util/TimeSkewMonitor.kt
+++ b/app/src/main/kotlin/com/example/calendar/util/TimeSkewMonitor.kt
@@ -1,0 +1,69 @@
+package com.example.calendar.util
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+
+/**
+ * Detects significant time differences between the device clock and a trusted reference
+ * such as the server time or the timestamp of the last successful synchronization.
+ */
+class TimeSkewMonitor(
+    private val referenceTimeProvider: suspend () -> Instant?,
+    private val tolerance: Duration = Duration.ofMinutes(5),
+    private val clock: Clock = Clock.systemUTC(),
+    private val referenceRecorder: suspend (Instant) -> Unit = {}
+) {
+    /**
+     * Evaluates the current device time against the reference. When the absolute
+     * difference exceeds the configured [tolerance], a [TimeSkewResult.SkewExceeded]
+     * is returned with the direction of the skew.
+     */
+    suspend fun evaluate(): TimeSkewResult {
+        val reference = referenceTimeProvider() ?: return TimeSkewResult.Unknown
+        val now = clock.instant()
+        val rawDifference = Duration.between(reference, now)
+        val direction = if (rawDifference.isNegative) {
+            TimeSkewDirection.DeviceBehind
+        } else {
+            TimeSkewDirection.DeviceAhead
+        }
+        val difference = rawDifference.absoluteValue()
+
+        return if (difference > tolerance) {
+            TimeSkewResult.SkewExceeded(difference, direction)
+        } else {
+            TimeSkewResult.WithinTolerance(difference, direction)
+        }
+    }
+
+    private fun Duration.absoluteValue(): Duration = if (isNegative) negated() else this
+
+    /**
+     * Records the provided [reference] instant as the latest trusted timestamp. This should
+     * be invoked after a successful synchronization with the server or any operation that
+     * confirms the device clock is aligned with authoritative time.
+     */
+    suspend fun recordReference(reference: Instant = clock.instant()) {
+        referenceRecorder(reference)
+    }
+}
+
+sealed class TimeSkewResult {
+    data class WithinTolerance(
+        val difference: Duration,
+        val direction: TimeSkewDirection
+    ) : TimeSkewResult()
+
+    data class SkewExceeded(
+        val difference: Duration,
+        val direction: TimeSkewDirection
+    ) : TimeSkewResult()
+
+    data object Unknown : TimeSkewResult()
+}
+
+enum class TimeSkewDirection {
+    DeviceAhead,
+    DeviceBehind
+}

--- a/app/src/main/res/values-en/plurals.xml
+++ b/app/src/main/res/values-en/plurals.xml
@@ -1,0 +1,14 @@
+<resources>
+    <plurals name="time_skew_hours">
+        <item quantity="one">%d hour</item>
+        <item quantity="other">%d hours</item>
+    </plurals>
+    <plurals name="time_skew_minutes">
+        <item quantity="one">%d minute</item>
+        <item quantity="other">%d minutes</item>
+    </plurals>
+    <plurals name="time_skew_seconds">
+        <item quantity="one">%d second</item>
+        <item quantity="other">%d seconds</item>
+    </plurals>
+</resources>

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -1,0 +1,9 @@
+<resources>
+    <string name="app_name">Work01 Calendar</string>
+    <string name="reminder_action_complete">Complete</string>
+    <string name="reminder_action_snooze">Snooze</string>
+    <string name="reminder_notification_channel_name">Calendar reminders</string>
+    <string name="reminder_notification_channel_description">Stay informed about scheduled reminders for your events and tasks.</string>
+    <string name="time_skew_warning_ahead">Your device clock is %1$s ahead of the server time. Please verify your date and time settings.</string>
+    <string name="time_skew_warning_behind">Your device clock is %1$s behind the server time. Please verify your date and time settings.</string>
+</resources>

--- a/app/src/main/res/values/plurals.xml
+++ b/app/src/main/res/values/plurals.xml
@@ -1,0 +1,14 @@
+<resources>
+    <plurals name="time_skew_hours">
+        <item quantity="one">%d시간</item>
+        <item quantity="other">%d시간</item>
+    </plurals>
+    <plurals name="time_skew_minutes">
+        <item quantity="one">%d분</item>
+        <item quantity="other">%d분</item>
+    </plurals>
+    <plurals name="time_skew_seconds">
+        <item quantity="one">%d초</item>
+        <item quantity="other">%d초</item>
+    </plurals>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,4 +4,6 @@
     <string name="reminder_action_snooze">다시 알림</string>
     <string name="reminder_notification_channel_name">캘린더 리마인더</string>
     <string name="reminder_notification_channel_description">일정과 할 일 알림을 받아볼 수 있도록 예약된 리마인더를 안내합니다.</string>
+    <string name="time_skew_warning_ahead">기기 시간이 서버 기준보다 %1$s 빠릅니다. 날짜와 시간 설정을 확인해 주세요.</string>
+    <string name="time_skew_warning_behind">기기 시간이 서버 기준보다 %1$s 느립니다. 날짜와 시간 설정을 확인해 주세요.</string>
 </resources>

--- a/app/src/test/kotlin/com/example/calendar/ui/AgendaViewModelTest.kt
+++ b/app/src/test/kotlin/com/example/calendar/ui/AgendaViewModelTest.kt
@@ -14,9 +14,14 @@ import com.example.calendar.reminder.ReminderScheduler
 import com.example.calendar.reminder.ReminderStore
 import com.example.calendar.reminder.StoredReminder
 import com.example.calendar.scheduler.AgendaAggregator
+import com.example.calendar.util.TimeSkewMonitor
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
 import java.util.UUID
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -38,6 +43,12 @@ class AgendaViewModelTest {
 
     private val dispatcher = StandardTestDispatcher()
     private val today = LocalDate.of(2024, 1, 15)
+    private val testClock: Clock = Clock.fixed(
+        Instant.parse("2024-01-15T00:00:00Z"),
+        ZoneOffset.UTC
+    )
+    private var referenceInstant: Instant? = null
+    private lateinit var timeSkewMonitor: TimeSkewMonitor
 
     private lateinit var task: Task
     private lateinit var event: CalendarEvent
@@ -104,12 +115,20 @@ class AgendaViewModelTest {
         scheduler = RecordingReminderScheduler()
         store = InMemoryReminderStore()
         val orchestrator = ReminderOrchestrator(scheduler, store)
+        referenceInstant = testClock.instant()
+        timeSkewMonitor = TimeSkewMonitor(
+            referenceTimeProvider = { referenceInstant },
+            tolerance = Duration.ofMinutes(5),
+            clock = testClock,
+            referenceRecorder = { instant -> referenceInstant = instant }
+        )
 
         viewModel = AgendaViewModel(
             aggregator = aggregator,
             reminderOrchestrator = orchestrator,
             taskRepository = taskRepository,
-            eventRepository = eventRepository
+            eventRepository = eventRepository,
+            timeSkewMonitor = timeSkewMonitor
         )
 
         viewModel.setPeriod(AgendaPeriod.Day(today))
@@ -193,6 +212,28 @@ class AgendaViewModelTest {
         assertEquals(listOf(monthTask), snapshot.tasks)
         assertEquals(listOf(monthEvent), snapshot.events)
         assertEquals(1, snapshot.pendingCount)
+    }
+
+    @Test
+    fun `time skew warning is emitted when difference exceeds tolerance`() = runTest(dispatcher) {
+        referenceInstant = testClock.instant().minus(Duration.ofMinutes(20))
+
+        viewModel.setPeriod(AgendaPeriod.Week(weekStart))
+        advanceUntilIdle()
+
+        val message = viewModel.state.value.userMessage
+        assertTrue(message is AgendaUserMessage.TimeSkewWarning)
+    }
+
+    @Test
+    fun `time skew warning is not emitted when within tolerance`() = runTest(dispatcher) {
+        referenceInstant = testClock.instant().minus(Duration.ofMinutes(2))
+
+        viewModel.setPeriod(AgendaPeriod.Week(weekStart))
+        advanceUntilIdle()
+
+        val message = viewModel.state.value.userMessage
+        assertFalse(message is AgendaUserMessage.TimeSkewWarning)
     }
 
     @Test

--- a/app/src/test/kotlin/com/example/calendar/util/TimeSkewMonitorTest.kt
+++ b/app/src/test/kotlin/com/example/calendar/util/TimeSkewMonitorTest.kt
@@ -1,0 +1,65 @@
+package com.example.calendar.util
+
+import java.time.Clock
+import java.time.Duration
+import java.time.Instant
+import java.time.ZoneOffset
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TimeSkewMonitorTest {
+
+    private val clock: Clock = Clock.fixed(
+        Instant.parse("2024-01-01T12:00:00Z"),
+        ZoneOffset.UTC
+    )
+
+    @Test
+    fun `returns unknown when reference is missing`() = runTest {
+        val monitor = TimeSkewMonitor(
+            referenceTimeProvider = { null },
+            tolerance = Duration.ofMinutes(5),
+            clock = clock
+        )
+
+        val result = monitor.evaluate()
+
+        assertTrue(result is TimeSkewResult.Unknown)
+    }
+
+    @Test
+    fun `detects skew within tolerance`() = runTest {
+        val monitor = TimeSkewMonitor(
+            referenceTimeProvider = { clock.instant().minus(Duration.ofMinutes(2)) },
+            tolerance = Duration.ofMinutes(5),
+            clock = clock
+        )
+
+        val result = monitor.evaluate()
+
+        assertTrue(result is TimeSkewResult.WithinTolerance)
+        result as TimeSkewResult.WithinTolerance
+        assertEquals(Duration.ofMinutes(2), result.difference)
+        assertEquals(TimeSkewDirection.DeviceAhead, result.direction)
+    }
+
+    @Test
+    fun `detects skew exceeding tolerance`() = runTest {
+        val monitor = TimeSkewMonitor(
+            referenceTimeProvider = { clock.instant().plus(Duration.ofMinutes(10)) },
+            tolerance = Duration.ofMinutes(5),
+            clock = clock
+        )
+
+        val result = monitor.evaluate()
+
+        assertTrue(result is TimeSkewResult.SkewExceeded)
+        result as TimeSkewResult.SkewExceeded
+        assertEquals(Duration.ofMinutes(10), result.difference)
+        assertEquals(TimeSkewDirection.DeviceBehind, result.direction)
+    }
+}


### PR DESCRIPTION
## Summary
- add a reusable TimeSkewMonitor helper to compare device and reference time sources
- inject the monitor into the agenda ViewModel and surface skew warnings through the UI with localized strings
- cover the new behavior with unit tests for the monitor and AgendaViewModel

## Testing
- ./gradlew test *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f88723c768832d8015893e545128a5