### PR TITLE
Add TalkBack agenda UI instrumentation tests

### DIFF
--- a/app/src/androidTest/kotlin/com/example/calendar/ui/agenda/AgendaScreenTest.kt
+++ b/app/src/androidTest/kotlin/com/example/calendar/ui/agenda/AgendaScreenTest.kt
@@ -9,8 +9,11 @@ import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertContentDescriptionEquals
+import androidx.compose.ui.test.assertDoesNotExist
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsFocused
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasParent
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
@@ -25,10 +28,14 @@ import com.example.calendar.ui.AgendaUiState
 import com.example.calendar.ui.AgendaUserMessage
 import com.example.calendar.ui.QuickAddType
 import com.example.calendar.ui.theme.CalendarTheme
+import java.time.DayOfWeek
 import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters
+import java.util.concurrent.atomic.AtomicInteger
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
+import org.junit.Assert.assertEquals
 
 @RunWith(AndroidJUnit4::class)
 class AgendaScreenTest {
@@ -205,6 +212,224 @@ class AgendaScreenTest {
 
         composeTestRule.onNodeWithText(AgendaText.QuickAddResult.taskSuccess)
             .assertIsDisplayed()
+    }
+
+    @Test
+    fun agendaScreen_tabSelection_updatesAccessibleStateDescriptions() {
+        val initialState = previewAgendaUiState()
+        val snapshot = requireNotNull(initialState.snapshot)
+        val focusDate = snapshot.rangeStart
+        val weekStart = focusDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+
+        composeTestRule.setContent {
+            var selectedTab by remember { mutableStateOf(AgendaTab.Daily) }
+
+            CalendarTheme {
+                AgendaScreen(
+                    uiState = initialState,
+                    selectedTab = selectedTab,
+                    onTabSelected = { selectedTab = it },
+                    onPreviousPeriod = {},
+                    onNextPeriod = {},
+                    onToggleTask = {},
+                    onTaskClick = {},
+                    onEventClick = {},
+                    onCycleCompletedTaskFilter = {},
+                    onToggleShowRecurringEvents = {},
+                    onWeekDaySelected = {},
+                    onMonthDaySelected = {},
+                    focusedDay = focusDate,
+                    period = when (selectedTab) {
+                        AgendaTab.Daily -> AgendaPeriod.Day(focusDate)
+                        AgendaTab.Weekly -> AgendaPeriod.Week(weekStart)
+                        AgendaTab.Monthly -> AgendaPeriod.Month(focusDate.year, focusDate.monthValue)
+                    },
+                    onQuickAddClick = {}
+                )
+            }
+        }
+
+        val dailyTab = composeTestRule.onNodeWithContentDescription(AgendaText.Accessibility.dailyTab)
+        dailyTab.assertContentDescriptionEquals(AgendaText.Accessibility.dailyTab)
+        dailyTab.performSemanticsAction(SemanticsActions.RequestFocus)
+        dailyTab.assert(
+            SemanticsMatcher.expectValue(
+                SemanticsProperties.StateDescription,
+                AgendaText.Accessibility.selected
+            )
+        )
+
+        val weeklyTab = composeTestRule.onNodeWithContentDescription(AgendaText.Accessibility.weeklyTab)
+        weeklyTab.assertContentDescriptionEquals(AgendaText.Accessibility.weeklyTab)
+        weeklyTab.performSemanticsAction(SemanticsActions.RequestFocus)
+        weeklyTab.performSemanticsAction(SemanticsActions.PerformClick)
+
+        composeTestRule.waitForIdle()
+
+        weeklyTab.assert(
+            SemanticsMatcher.expectValue(
+                SemanticsProperties.StateDescription,
+                AgendaText.Accessibility.selected
+            )
+        )
+        composeTestRule.onNodeWithContentDescription(AgendaText.Accessibility.dailyTab)
+            .assert(
+                SemanticsMatcher.expectValue(
+                    SemanticsProperties.StateDescription,
+                    AgendaText.Accessibility.notSelected
+                )
+            )
+
+        val monthlyTab = composeTestRule.onNodeWithContentDescription(AgendaText.Accessibility.monthlyTab)
+        monthlyTab.assertContentDescriptionEquals(AgendaText.Accessibility.monthlyTab)
+        monthlyTab.performSemanticsAction(SemanticsActions.RequestFocus)
+        monthlyTab.performSemanticsAction(SemanticsActions.PerformClick)
+
+        composeTestRule.waitForIdle()
+
+        monthlyTab.assert(
+            SemanticsMatcher.expectValue(
+                SemanticsProperties.StateDescription,
+                AgendaText.Accessibility.selected
+            )
+        )
+        composeTestRule.onNodeWithContentDescription(AgendaText.Accessibility.weeklyTab)
+            .assert(
+                SemanticsMatcher.expectValue(
+                    SemanticsProperties.StateDescription,
+                    AgendaText.Accessibility.notSelected
+                )
+            )
+    }
+
+    @Test
+    fun agendaScreen_filtersAndSnackbar_flowUpdatesAccessibility() {
+        val initialState = previewAgendaUiState().copy(
+            userMessage = AgendaUserMessage.QuickAddSuccess(QuickAddType.Task)
+        )
+        val snapshot = requireNotNull(initialState.snapshot)
+        val focusDate = snapshot.rangeStart
+        val weekStart = focusDate.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY))
+        val userMessageShownCount = AtomicInteger(0)
+
+        composeTestRule.setContent {
+            var uiState by remember { mutableStateOf(initialState) }
+            var selectedTab by remember { mutableStateOf(AgendaTab.Daily) }
+
+            CalendarTheme {
+                AgendaScreen(
+                    uiState = uiState,
+                    selectedTab = selectedTab,
+                    onTabSelected = { selectedTab = it },
+                    onPreviousPeriod = {},
+                    onNextPeriod = {},
+                    onToggleTask = { task ->
+                        uiState = uiState.copy(
+                            snapshot = uiState.snapshot?.let { snapshot ->
+                                val updatedTask = task.toggleCompletion()
+                                snapshot.copy(
+                                    tasks = snapshot.tasks.map { existing ->
+                                        if (existing.id == task.id) updatedTask else existing
+                                    }
+                                )
+                            }
+                        )
+                    },
+                    onTaskClick = {},
+                    onEventClick = {},
+                    onCycleCompletedTaskFilter = {
+                        uiState = uiState.copy(
+                            filters = uiState.filters.copy(
+                                completedTaskFilter = uiState.filters.completedTaskFilter.next()
+                            )
+                        )
+                    },
+                    onToggleShowRecurringEvents = {
+                        uiState = uiState.copy(
+                            filters = uiState.filters.copy(
+                                showRecurringEvents = !uiState.filters.showRecurringEvents
+                            )
+                        )
+                    },
+                    onWeekDaySelected = {},
+                    onMonthDaySelected = {},
+                    focusedDay = focusDate,
+                    period = when (selectedTab) {
+                        AgendaTab.Daily -> AgendaPeriod.Day(focusDate)
+                        AgendaTab.Weekly -> AgendaPeriod.Week(weekStart)
+                        AgendaTab.Monthly -> AgendaPeriod.Month(focusDate.year, focusDate.monthValue)
+                    },
+                    onQuickAddClick = {},
+                    onUserMessageShown = {
+                        userMessageShownCount.incrementAndGet()
+                        uiState = uiState.copy(userMessage = null)
+                    }
+                )
+            }
+        }
+
+        composeTestRule.onNodeWithText(AgendaText.QuickAddResult.taskSuccess)
+            .assertIsDisplayed()
+
+        composeTestRule.mainClock.autoAdvance = false
+        try {
+            composeTestRule.mainClock.advanceTimeBy(5_000L)
+            composeTestRule.waitForIdle()
+        } finally {
+            composeTestRule.mainClock.autoAdvance = true
+        }
+
+        composeTestRule.runOnIdle {
+            assertEquals(1, userMessageShownCount.get())
+        }
+
+        composeTestRule.onNodeWithText(AgendaText.QuickAddResult.taskSuccess)
+            .assertDoesNotExist()
+
+        val filterCycleOrder = listOf(
+            AgendaText.Agenda.filterAllTasks to AgendaText.Agenda.filterAllTasksDescription,
+            AgendaText.Agenda.filterHideCompleted to AgendaText.Agenda.filterHideCompletedDescription,
+            AgendaText.Agenda.filterCompletedOnly to AgendaText.Agenda.filterCompletedOnlyDescription
+        )
+
+        filterCycleOrder.windowed(size = 2, step = 1, partialWindows = true).forEach { window ->
+            val current = window.first()
+            val node = composeTestRule.onNodeWithText(current.first)
+            node.assert(
+                SemanticsMatcher.expectValue(
+                    SemanticsProperties.StateDescription,
+                    current.second
+                )
+            )
+            if (window.size == 2) {
+                node.performSemanticsAction(SemanticsActions.PerformClick)
+                composeTestRule.waitForIdle()
+                val next = window[1]
+                composeTestRule.onNodeWithText(next.first)
+                    .assert(
+                        SemanticsMatcher.expectValue(
+                            SemanticsProperties.StateDescription,
+                            next.second
+                        )
+                    )
+            } else {
+                node.performSemanticsAction(SemanticsActions.PerformClick)
+                composeTestRule.waitForIdle()
+                composeTestRule.onNodeWithText(filterCycleOrder.first().first)
+                    .assert(
+                        SemanticsMatcher.expectValue(
+                            SemanticsProperties.StateDescription,
+                            filterCycleOrder.first().second
+                        )
+                    )
+            }
+        }
+
+        val recurringFilter = composeTestRule.onNodeWithText(AgendaText.Agenda.showRecurring)
+        recurringFilter.assertIsSelected()
+        recurringFilter.performSemanticsAction(SemanticsActions.PerformClick)
+        composeTestRule.waitForIdle()
+        recurringFilter.assertIsNotSelected()
     }
 
     private companion object {


### PR DESCRIPTION
## Summary
- add an instrumentation test that exercises TalkBack focus and selection on the agenda tabs
- cover agenda filters and snackbar dismissal flow to ensure accessibility state descriptions stay in sync

## Testing
- not run (instrumentation tests require an Android device)


------
https://chatgpt.com/codex/tasks/task_e_68f887280dd4832d8b0ac88a373babd6