### PR TITLE
Enable AndroidX support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true


### PR DESCRIPTION
## Summary
- add a `gradle.properties` file so the build explicitly opts into AndroidX
- this resolves the build warning/error emitted during Gradle sync

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69193410461c832d8419d769185c8fa0)